### PR TITLE
Add sheet metadata sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Campfire
+
+## Syncing Metadata from Google Sheets
+
+This project includes a utility script `sync.js` that copies ad metadata from a
+Google Sheet into Firestore.
+
+### Setup
+
+1. Install dependencies (Firebase Admin SDK and Google APIs):
+   ```bash
+   npm install
+   ```
+2. Provide a Firebase service account key and set the environment variable
+   `GOOGLE_APPLICATION_CREDENTIALS` to its path. The storage bucket can be
+   overridden with `FIREBASE_STORAGE_BUCKET`.
+3. Run the script:
+   ```bash
+   npm run sync
+   ```
+
+The script reads the `sheetId` field from each document in the `adBatches`
+collection, loads rows from the `Recipes` tab, and writes metadata documents
+under `adBatches/{batchId}/ads`.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
     "firebase": "^11.7.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.2"
+    "react-router-dom": "^6.22.2",
+    "firebase-admin": "^11.10.1",
+    "googleapis": "^124.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
@@ -15,7 +17,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "sync": "node sync.js"
   },
   "license": "UNLICENSED"
 }

--- a/sync.js
+++ b/sync.js
@@ -1,0 +1,81 @@
+const admin = require('firebase-admin');
+const { google } = require('googleapis');
+
+// Path to the service account key is read from the standard env var
+const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (!serviceAccountPath) {
+  console.error('GOOGLE_APPLICATION_CREDENTIALS env var is not set.');
+  process.exit(1);
+}
+
+admin.initializeApp({
+  credential: admin.credential.cert(require(serviceAccountPath)),
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET || 'tak-campfire.appspot.com',
+});
+
+const db = admin.firestore();
+const bucketName = admin.app().options.storageBucket;
+
+async function fetchRecipes(sheetId) {
+  const auth = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+  });
+  const sheets = google.sheets({ version: 'v4', auth });
+  const { data } = await sheets.spreadsheets.values.get({
+    spreadsheetId: sheetId,
+    range: 'Recipes!A:J',
+  });
+
+  const rows = data.values || [];
+  const recipes = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    const filename = row[2];
+    if (!filename) continue;
+    recipes.push({
+      filename,
+      copy: row[7] || '',
+      audience: row[8] || '',
+      angle: row[9] || '',
+    });
+  }
+  return recipes;
+}
+
+async function syncBatch(doc) {
+  const batchData = doc.data();
+  const sheetId = batchData.sheetId;
+  if (!sheetId) return;
+  const clientId = batchData.clientId;
+
+  const recipes = await fetchRecipes(sheetId);
+  for (const r of recipes) {
+    const adUrl = `https://firebasestorage.googleapis.com/v0/b/${bucketName}/o/${encodeURIComponent(r.filename)}?alt=media`;
+    await db
+      .collection('adBatches')
+      .doc(doc.id)
+      .collection('ads')
+      .doc(r.filename)
+      .set({
+        clientId,
+        filename: r.filename,
+        adUrl,
+        copy: r.copy,
+        audience: r.audience,
+        angle: r.angle,
+      });
+  }
+  console.log(`Synced ${recipes.length} ads for batch ${doc.id}`);
+}
+
+async function main() {
+  const snapshot = await db.collection('adBatches').get();
+  for (const doc of snapshot.docs) {
+    await syncBatch(doc);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `sync.js` to copy ad metadata from Google Sheets to Firestore
- document sync script usage
- add `firebase-admin` and `googleapis` packages and a `sync` npm script

## Testing
- `npm run sync` *(fails: Cannot find module 'firebase-admin')*