### PR TITLE
Implement role-based dashboards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,10 @@ import Login from './Login';
 import Review from './Review';
 import CreateAdGroup from './CreateAdGroup';
 import AdGroupDetail from './AdGroupDetail';
+import DesignerDashboard from './DesignerDashboard';
+import ClientDashboard from './ClientDashboard';
+import RoleGuard from './RoleGuard';
+import useUserRole from './useUserRole';
 
 const App = () => {
   const [user, setUser] = React.useState(null);
@@ -21,35 +25,101 @@ const App = () => {
     return () => unsub();
   }, []);
 
-  if (loading) {
+  const { role, loading: roleLoading } = useUserRole(user?.uid);
+
+  if (loading || roleLoading) {
     return <div className="text-center mt-10">Loading...</div>;
+  }
+
+  if (user && !role) {
+    return (
+      <div className="flex items-center justify-center min-h-screen text-center">
+        No role assigned to this account. Please contact support.
+      </div>
+    );
   }
 
   return (
     <Router>
       <div className="min-h-screen flex flex-col">
         <header className="p-2 bg-gray-100 text-sm">
-          {user && (
+          {user && role && (
             <nav className="space-x-4">
-              <Link to="/">Review</Link>
-              <Link to="/create-group">Create Group</Link>
+              {role === 'client' && <Link to="/dashboard/client">Dashboard</Link>}
+              {role === 'designer' && (
+                <>
+                  <Link to="/dashboard/designer">Dashboard</Link>
+                  <Link to="/create-group">Create Group</Link>
+                </>
+              )}
             </nav>
           )}
         </header>
         <div className="flex-grow">
           <Routes>
-            <Route path="/login" element={<Login onLogin={() => setUser(auth.currentUser)} />} />
+            <Route
+              path="/login"
+              element={
+                user ? (
+                  <Navigate to={`/dashboard/${role}`} replace />
+                ) : (
+                  <Login onLogin={() => setUser(auth.currentUser)} />
+                )
+              }
+            />
             <Route
               path="/"
-              element={user ? <Review user={user} /> : <Navigate to="/login" replace />}
+              element={
+                user ? <Navigate to={`/dashboard/${role}`} replace /> : <Navigate to="/login" replace />
+              }
+            />
+            <Route
+              path="/dashboard/designer"
+              element={
+                user ? (
+                  <RoleGuard requiredRole="designer" userRole={role} loading={roleLoading}>
+                    <DesignerDashboard />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/dashboard/client"
+              element={
+                user ? (
+                  <RoleGuard requiredRole="client" userRole={role} loading={roleLoading}>
+                    <ClientDashboard user={user} />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
             />
             <Route
               path="/create-group"
-              element={user ? <CreateAdGroup /> : <Navigate to="/login" replace />}
+              element={
+                user ? (
+                  <RoleGuard requiredRole="designer" userRole={role} loading={roleLoading}>
+                    <CreateAdGroup />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
             />
             <Route
               path="/ad-group/:id"
-              element={user ? <AdGroupDetail /> : <Navigate to="/login" replace />}
+              element={
+                user ? (
+                  <RoleGuard requiredRole="designer" userRole={role} loading={roleLoading}>
+                    <AdGroupDetail />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
             />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Review from './Review';
+
+const ClientDashboard = ({ user }) => {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Client Dashboard</h1>
+      <Review user={user} />
+    </div>
+  );
+};
+
+export default ClientDashboard;

--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CreateAdGroup from './CreateAdGroup';
+
+const DesignerDashboard = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Designer Dashboard</h1>
+      <CreateAdGroup />
+    </div>
+  );
+};
+
+export default DesignerDashboard;

--- a/src/RoleGuard.jsx
+++ b/src/RoleGuard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+const RoleGuard = ({ loading, userRole, requiredRole, children }) => {
+  if (loading) {
+    return <div className="text-center mt-10">Loading...</div>;
+  }
+
+  if (userRole && userRole !== requiredRole) {
+    return <Navigate to={`/dashboard/${userRole}`} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default RoleGuard;

--- a/src/useUserRole.js
+++ b/src/useUserRole.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from './firebase/config';
+
+const useUserRole = (uid) => {
+  const [role, setRole] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!uid) {
+      setRole(null);
+      setLoading(false);
+      return;
+    }
+
+    const fetchRole = async () => {
+      setLoading(true);
+      try {
+        const snap = await getDoc(doc(db, 'users', uid));
+        if (snap.exists()) {
+          setRole(snap.data().role || null);
+        } else {
+          setRole(null);
+        }
+      } catch (err) {
+        console.error('Failed to fetch user role', err);
+        setRole(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRole();
+  }, [uid]);
+
+  return { role, loading };
+};
+
+export default useUserRole;


### PR DESCRIPTION
## Summary
- fetch user roles from Firestore with `useUserRole`
- protect routes with a new `RoleGuard` component
- add `DesignerDashboard` and `ClientDashboard`
- route users to dashboards based on their role

## Testing
- `npm run build` *(fails: vite not found)*