### PR TITLE
Fix Firebase storage bucket configuration

### DIFF
--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -8,7 +8,9 @@ const firebaseConfig = {
   apiKey: "AIzaSyDZ7h9KXAwIvzqFf9gMrMBOJvkMxSMjjRw",
   authDomain: "tak-campfire.firebaseapp.com",
   projectId: "tak-campfire",
-  storageBucket: "tak-campfire.appspot.com", // ✅ fixed this
+  // Bucket is manually created in Google Cloud Storage, not a Firebase-managed
+  // bucket, so omit the .appspot.com suffix.
+  storageBucket: "tak-campfire-main",
   messagingSenderId: "198332728326",
   appId: "1:198332728326:web:d7eec9d577fb30fa916f87"
 };


### PR DESCRIPTION
## Summary
- correct Firebase storage bucket for manual GCS bucket

## Testing
- `npm run build` *(fails: vite not found)*