### PR TITLE
Add brand code select to CreateAdGroup

### DIFF
--- a/src/CreateAdGroup.jsx
+++ b/src/CreateAdGroup.jsx
@@ -1,16 +1,39 @@
 // © 2025 Studio Tak. All rights reserved.
 // This file is part of a proprietary software project. Do not distribute.
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { doc, getDoc, collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { db, auth } from './firebase/config';
 
 const CreateAdGroup = () => {
   const [name, setName] = useState('');
   const [brand, setBrand] = useState('');
+  const [brandCodes, setBrandCodes] = useState([]);
   const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchCodes = async () => {
+      if (!auth.currentUser?.uid) {
+        setBrandCodes([]);
+        return;
+      }
+      try {
+        const snap = await getDoc(doc(db, 'users', auth.currentUser.uid));
+        const codes = snap.exists() ? snap.data().brandCodes : [];
+        if (Array.isArray(codes)) {
+          setBrandCodes(codes);
+        } else {
+          setBrandCodes([]);
+        }
+      } catch (err) {
+        console.error('Failed to fetch brand codes', err);
+        setBrandCodes([]);
+      }
+    };
+    fetchCodes();
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -49,13 +72,23 @@ const CreateAdGroup = () => {
         </div>
         <div>
           <label className="block mb-1 text-sm font-medium">Brand</label>
-          <input
-            type="text"
-            value={brand}
-            onChange={(e) => setBrand(e.target.value)}
-            className="w-full p-2 border rounded"
-            required
-          />
+          {brandCodes.length > 0 ? (
+            <select
+              value={brand}
+              onChange={(e) => setBrand(e.target.value)}
+              className="w-full p-2 border rounded"
+              required
+            >
+              <option value="">Select brand</option>
+              {brandCodes.map((code) => (
+                <option key={code} value={code}>
+                  {code}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <p className="text-sm text-gray-500">No brands assigned</p>
+          )}
         </div>
         <div>
           <label className="block mb-1 text-sm font-medium">Notes</label>


### PR DESCRIPTION
## Summary
- fetch user's brand codes from Firestore
- display brand list in a select element
- handle missing brand codes

## Testing
- `npm test` *(fails: Missing script)*