### PR TITLE
Add ad group listing with asset status counts

### DIFF
--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -1,9 +1,61 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { signOut } from 'firebase/auth';
-import { auth } from './firebase/config';
+import { Link } from 'react-router-dom';
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+} from 'firebase/firestore';
+import { auth, db } from './firebase/config';
 import CreateAdGroup from './CreateAdGroup';
 
 const DesignerDashboard = () => {
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchGroups = async () => {
+      setLoading(true);
+      try {
+        const q = query(
+          collection(db, 'adGroups'),
+          where('uploadedBy', '==', auth.currentUser?.uid || '')
+        );
+        const snap = await getDocs(q);
+        const list = await Promise.all(
+          snap.docs.map(async (d) => {
+            let approved = 0;
+            let rejected = 0;
+            let edit = 0;
+            const assetsSnap = await getDocs(
+              collection(db, 'adGroups', d.id, 'assets')
+            );
+            assetsSnap.forEach((a) => {
+              const status = a.data().status;
+              if (status === 'approved') approved += 1;
+              if (status === 'rejected') rejected += 1;
+              if (status === 'edit') edit += 1;
+            });
+            return {
+              id: d.id,
+              ...d.data(),
+              counts: { approved, rejected, edit },
+            };
+          })
+        );
+        setGroups(list);
+      } catch (err) {
+        console.error('Failed to fetch groups', err);
+        setGroups([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchGroups();
+  }, []);
+
   return (
     <div className="p-4">
       <div className="flex justify-between items-start">
@@ -15,6 +67,50 @@ const DesignerDashboard = () => {
           Log Out
         </button>
       </div>
+
+      <div className="mb-8">
+        <h2 className="text-xl mb-2">My Ad Groups</h2>
+        {loading ? (
+          <p>Loading groups...</p>
+        ) : groups.length === 0 ? (
+          <p>No ad groups found.</p>
+        ) : (
+          <table className="min-w-full border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border px-2 py-1">Group Name</th>
+                <th className="border px-2 py-1">Brand</th>
+                <th className="border px-2 py-1">Status</th>
+                <th className="border px-2 py-1">Approved</th>
+                <th className="border px-2 py-1">Rejected</th>
+                <th className="border px-2 py-1">Edit</th>
+                <th className="border px-2 py-1">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map((g) => (
+                <tr key={g.id}>
+                  <td className="border px-2 py-1">{g.name}</td>
+                  <td className="border px-2 py-1">{g.brandCode}</td>
+                  <td className="border px-2 py-1">{g.status}</td>
+                  <td className="border px-2 py-1 text-center">{g.counts.approved}</td>
+                  <td className="border px-2 py-1 text-center">{g.counts.rejected}</td>
+                  <td className="border px-2 py-1 text-center">{g.counts.edit}</td>
+                  <td className="border px-2 py-1 text-center">
+                    <Link
+                      to={`/ad-group/${g.id}`}
+                      className="text-blue-500 underline"
+                    >
+                      View Details
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
       <CreateAdGroup />
     </div>
   );


### PR DESCRIPTION
## Summary
- query ad groups uploaded by the current user
- count assets by status for each group
- show a table of groups with counts and links to the detail view

## Testing
- `npm test` *(fails: Missing script)*