### PR TITLE
Add Jest test setup

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+  ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -12,13 +12,21 @@
     "autoprefixer": "^10.4.2",
     "postcss": "^8.4.16",
     "tailwindcss": "^3.4.0",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.23.9",
+    "@babel/preset-react": "^7.23.3",
+    "jest-environment-jsdom": "^29.7.0"
   },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "sync": "node sync.js"
+    "sync": "node sync.js",
+    "test": "jest"
   },
   "license": "UNLICENSED"
 }

--- a/src/CreateAdGroup.test.jsx
+++ b/src/CreateAdGroup.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import CreateAdGroup from './CreateAdGroup';
+
+jest.mock('./firebase/config', () => ({ db: {}, auth: {} }));
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  addDoc: jest.fn(() => Promise.resolve({ id: '1' })),
+  serverTimestamp: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+test('renders Create Ad Group heading', () => {
+  render(
+    <MemoryRouter>
+      <CreateAdGroup />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/Create Ad Group/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Jest configuration with Babel
- add React Testing Library and create initial test for CreateAdGroup
- update `package.json` devDependencies and test script

## Testing
- `npm test --silent` *(fails: jest not found)*