### PR TITLE
Use env vars for Firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,26 @@ Google Sheet into Firestore.
 The script reads the `sheetId` field from each document in the `adBatches`
 collection, loads rows from the `Recipes` tab, and writes metadata documents
 under `adBatches/{batchId}/ads`.
+
+## Environment Variables
+
+The React application reads Firebase configuration values from Vite's
+environment. Create a `.env` file in the project root with the following
+variables:
+
+```bash
+VITE_FIREBASE_API_KEY=your-api-key
+VITE_FIREBASE_AUTH_DOMAIN=your-auth-domain
+VITE_FIREBASE_PROJECT_ID=your-project-id
+VITE_FIREBASE_STORAGE_BUCKET=your-storage-bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+VITE_FIREBASE_APP_ID=your-app-id
+```
+
+These values correspond to your Firebase project's configuration. Vite will load
+them automatically when running `npm run dev` or `npm run build`.
+
+The `sync.js` utility also reads `GOOGLE_APPLICATION_CREDENTIALS` and
+`FIREBASE_STORAGE_BUCKET` from the environment. If you use a `.env` file, include
+those variables as well so `npm run sync` can locate your service account key and
+bucket.

--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -4,15 +4,17 @@ import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 
 // ✅ Fixed: Correct Firebase config
+// Configuration is read from the Vite environment so that sensitive values can
+// be provided via a `.env` file.
 const firebaseConfig = {
-  apiKey: "AIzaSyDZ7h9KXAwIvzqFf9gMrMBOJvkMxSMjjRw",
-  authDomain: "tak-campfire.firebaseapp.com",
-  projectId: "tak-campfire",
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
   // Bucket is manually created in Google Cloud Storage, not a Firebase-managed
-  // bucket, so omit the .appspot.com suffix.
-  storageBucket: "tak-campfire-main",
-  messagingSenderId: "198332728326",
-  appId: "1:198332728326:web:d7eec9d577fb30fa916f87"
+  // bucket, so omit the `.appspot.com` suffix.
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
 };
 
 // ✅ Initialize Firebase

--- a/sync.js
+++ b/sync.js
@@ -1,5 +1,18 @@
 const admin = require('firebase-admin');
 const { google } = require('googleapis');
+const fs = require('fs');
+const path = require('path');
+
+// Load variables from .env if present (without external dependencies)
+const envPath = path.join(__dirname, '.env');
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([^#=]+)\s*=\s*(.*)\s*$/);
+    if (m && !process.env[m[1]]) {
+      process.env[m[1]] = m[2];
+    }
+  }
+}
 
 // Path to the service account key is read from the standard env var
 const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;


### PR DESCRIPTION
## Summary
- pull Firebase config from Vite env vars
- load `.env` file for the sync script
- document required environment variables

## Testing
- `npm test` *(fails: Missing script)*