### PR TITLE
Add delete asset tests

### DIFF
--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -12,7 +12,9 @@ import {
   serverTimestamp,
   writeBatch,
 } from 'firebase/firestore';
-import { db } from './firebase/config';
+import { db, storage } from './firebase/config';
+import { ref, deleteObject } from 'firebase/storage';
+import { deleteDoc } from 'firebase/firestore';
 import { uploadFile } from './uploadFile';
 
 const AdGroupDetail = () => {
@@ -61,6 +63,15 @@ const AdGroupDetail = () => {
     setUploading(false);
   };
 
+  const deleteAsset = async (asset) => {
+    try {
+      await deleteObject(ref(storage, `adGroups/${id}/${asset.filename}`));
+      await deleteDoc(doc(db, 'adGroups', id, 'assets', asset.id));
+    } catch (err) {
+      console.error('Failed to delete asset', err);
+    }
+  };
+
   const markReady = async () => {
     setReadyLoading(true);
     try {
@@ -107,7 +118,7 @@ const AdGroupDetail = () => {
               <th className="px-2 py-1 text-left">Filename</th>
               <th className="px-2 py-1 text-left">Status</th>
               <th className="px-2 py-1 text-left">Comment</th>
-              <th className="px-2 py-1 text-left">&nbsp;</th>
+              <th className="px-2 py-1 text-left">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -125,6 +136,12 @@ const AdGroupDetail = () => {
                   >
                     View
                   </a>
+                  <button
+                    onClick={() => deleteAsset(a)}
+                    className="ml-2 text-red-600 hover:underline"
+                  >
+                    Delete
+                  </button>
                 </td>
               </tr>
             ))}

--- a/src/AdGroupDetail.test.jsx
+++ b/src/AdGroupDetail.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import AdGroupDetail from './AdGroupDetail';
+
+jest.mock('./firebase/config', () => ({ db: {}, storage: {} }));
+
+const deleteDoc = jest.fn();
+const getDoc = jest.fn(() => Promise.resolve({
+  exists: () => true,
+  id: 'group1',
+  data: () => ({ name: 'My Group', brandCode: 'B', status: 'draft' })
+}));
+const onSnapshot = jest.fn((ref, cb) => {
+  cb({ docs: [{ id: 'asset1', data: () => ({ filename: 'file.png', status: 'draft', comment: null, firebaseUrl: '#' }) }] });
+  return () => {};
+});
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(() => ({})),
+  getDoc,
+  updateDoc: jest.fn(),
+  collection: jest.fn(() => ({})),
+  addDoc: jest.fn(),
+  onSnapshot,
+  serverTimestamp: jest.fn(),
+  writeBatch: jest.fn(() => ({ update: jest.fn(), commit: jest.fn() })),
+  deleteDoc,
+}));
+
+const deleteObject = jest.fn(() => Promise.resolve());
+
+jest.mock('firebase/storage', () => ({
+  ref: jest.fn(() => ({})),
+  deleteObject,
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '123' }),
+}));
+
+describe('AdGroupDetail deletion', () => {
+  test('renders Delete buttons', async () => {
+    render(
+      <MemoryRouter>
+        <AdGroupDetail />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
+  });
+
+  test('calls delete methods when Delete clicked', async () => {
+    render(
+      <MemoryRouter>
+        <AdGroupDetail />
+      </MemoryRouter>
+    );
+    const btn = await screen.findByText('Delete');
+    fireEvent.click(btn);
+    expect(deleteObject).toHaveBeenCalledTimes(1);
+    expect(deleteDoc).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- enable deletion of ad group assets
- render Delete button for each asset
- add tests covering delete behavior

## Testing
- `npm test` *(fails: jest not found)*