### PR TITLE
Use brand codes when loading ads

### DIFF
--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -3,7 +3,7 @@ import { signOut } from 'firebase/auth';
 import { auth } from './firebase/config';
 import Review from './Review';
 
-const ClientDashboard = ({ user }) => {
+const ClientDashboard = ({ user, brandCodes = [] }) => {
   return (
     <div className="p-4">
       <div className="flex justify-between items-start">
@@ -15,7 +15,7 @@ const ClientDashboard = ({ user }) => {
           Log Out
         </button>
       </div>
-      <Review user={user} />
+      <Review user={user} brandCodes={brandCodes} />
     </div>
   );
 };

--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -11,7 +11,7 @@ import {
 } from 'firebase/firestore';
 import { db } from './firebase/config';
 
-const Review = ({ user }) => {
+const Review = ({ user, brandCodes = [] }) => {
   const [ads, setAds] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [comment, setComment] = useState('');
@@ -26,7 +26,7 @@ const Review = ({ user }) => {
       try {
         const q = query(
           collection(db, 'adBatches'),
-          where('clientId', '==', user.uid)
+          where('brandCode', 'in', brandCodes)
         );
         const snapshot = await getDocs(q);
         const list = [];
@@ -47,10 +47,14 @@ const Review = ({ user }) => {
       }
     };
 
-    if (user?.uid) {
-      fetchAds();
+    if (!user?.uid || brandCodes.length === 0) {
+      setAds([]);
+      setLoading(false);
+      return;
     }
-  }, [user]);
+
+    fetchAds();
+  }, [user, brandCodes]);
 
   const currentAd = ads[currentIndex];
 


### PR DESCRIPTION
## Summary
- allow `ClientDashboard` to receive brand codes and forward them to `Review`
- query ad batches by brand codes rather than client ID
- handle empty brand codes array in `Review`

## Testing
- `npm test --silent` *(fails: jest not found)*