### PR TITLE
Propagate brand codes throughout dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,7 @@ const App = () => {
     return () => unsub();
   }, []);
 
-  const { role, loading: roleLoading } = useUserRole(user?.uid);
+  const { role, brandCodes, loading: roleLoading } = useUserRole(user?.uid);
 
   const handleLogout = async () => {
     try {
@@ -107,7 +107,7 @@ const App = () => {
                     userRole={role}
                     loading={roleLoading}
                   >
-                    <DesignerDashboard />
+                    <DesignerDashboard brandCodes={brandCodes} />
                   </RoleGuard>
                 ) : (
                   <Navigate to="/login" replace />
@@ -123,7 +123,7 @@ const App = () => {
                     userRole={role}
                     loading={roleLoading}
                   >
-                    <ClientDashboard user={user} />
+                    <ClientDashboard user={user} brandCodes={brandCodes} />
                   </RoleGuard>
                 ) : (
                   <Navigate to="/login" replace />
@@ -139,7 +139,7 @@ const App = () => {
                     userRole={role}
                     loading={roleLoading}
                   >
-                    <CreateAdGroup />
+                    <CreateAdGroup brandCodes={brandCodes} />
                   </RoleGuard>
                 ) : (
                   <Navigate to="/login" replace />

--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -3,7 +3,7 @@ import { signOut } from 'firebase/auth';
 import { auth } from './firebase/config';
 import Review from './Review';
 
-const ClientDashboard = ({ user }) => {
+const ClientDashboard = ({ user, brandCodes }) => {
   return (
     <div className="p-4">
       <div className="flex justify-between items-start">

--- a/src/CreateAdGroup.jsx
+++ b/src/CreateAdGroup.jsx
@@ -1,39 +1,16 @@
 // © 2025 Studio Tak. All rights reserved.
 // This file is part of a proprietary software project. Do not distribute.
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { doc, getDoc, collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { db, auth } from './firebase/config';
 
-const CreateAdGroup = () => {
+const CreateAdGroup = ({ brandCodes = [] }) => {
   const [name, setName] = useState('');
   const [brand, setBrand] = useState('');
-  const [brandCodes, setBrandCodes] = useState([]);
   const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-
-  useEffect(() => {
-    const fetchCodes = async () => {
-      if (!auth.currentUser?.uid) {
-        setBrandCodes([]);
-        return;
-      }
-      try {
-        const snap = await getDoc(doc(db, 'users', auth.currentUser.uid));
-        const codes = snap.exists() ? snap.data().brandCodes : [];
-        if (Array.isArray(codes)) {
-          setBrandCodes(codes);
-        } else {
-          setBrandCodes([]);
-        }
-      } catch (err) {
-        console.error('Failed to fetch brand codes', err);
-        setBrandCodes([]);
-      }
-    };
-    fetchCodes();
-  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/src/CreateAdGroup.test.jsx
+++ b/src/CreateAdGroup.test.jsx
@@ -18,7 +18,7 @@ jest.mock('react-router-dom', () => ({
 test('renders Create Ad Group heading', () => {
   render(
     <MemoryRouter>
-      <CreateAdGroup />
+      <CreateAdGroup brandCodes={['test']} />
     </MemoryRouter>
   );
   expect(screen.getByText(/Create Ad Group/i)).toBeInTheDocument();

--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -13,7 +13,7 @@ import { listAll, ref, deleteObject } from 'firebase/storage';
 import { auth, db, storage } from './firebase/config';
 import CreateAdGroup from './CreateAdGroup';
 
-const DesignerDashboard = () => {
+const DesignerDashboard = ({ brandCodes }) => {
   const [groups, setGroups] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -155,7 +155,7 @@ const DesignerDashboard = () => {
         )}
       </div>
 
-      <CreateAdGroup />
+      <CreateAdGroup brandCodes={brandCodes} />
     </div>
   );
 };

--- a/src/useUserRole.js
+++ b/src/useUserRole.js
@@ -4,11 +4,13 @@ import { db } from './firebase/config';
 
 const useUserRole = (uid) => {
   const [role, setRole] = useState(null);
+  const [brandCodes, setBrandCodes] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!uid) {
       setRole(null);
+      setBrandCodes([]);
       setLoading(false);
       return;
     }
@@ -18,13 +20,22 @@ const useUserRole = (uid) => {
       try {
         const snap = await getDoc(doc(db, 'users', uid));
         if (snap.exists()) {
-          setRole(snap.data().role || null);
+          const data = snap.data();
+          setRole(data.role || null);
+          const codes = data.brandCodes;
+          if (Array.isArray(codes)) {
+            setBrandCodes(codes);
+          } else {
+            setBrandCodes([]);
+          }
         } else {
           setRole(null);
+          setBrandCodes([]);
         }
       } catch (err) {
         console.error('Failed to fetch user role', err);
         setRole(null);
+        setBrandCodes([]);
       } finally {
         setLoading(false);
       }
@@ -33,7 +44,7 @@ const useUserRole = (uid) => {
     fetchRole();
   }, [uid]);
 
-  return { role, loading };
+  return { role, brandCodes, loading };
 };
 
 export default useUserRole;


### PR DESCRIPTION
## Summary
- fetch brand codes in `useUserRole`
- pass `brandCodes` to `ClientDashboard`, `DesignerDashboard`, and `CreateAdGroup`
- adjust components to accept new prop
- update tests

## Testing
- `npm test` *(fails: jest not found)*