### PR TITLE
Remove clientId from response submissions

### DIFF
--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -53,19 +53,23 @@ const Review = ({ user }) => {
   }, [user]);
 
   const currentAd = ads[currentIndex];
+  const adUrl =
+    currentAd && typeof currentAd === 'object' ? currentAd.adUrl : currentAd;
+  const brandCode =
+    currentAd && typeof currentAd === 'object' ? currentAd.brandCode : undefined;
 
   const submitResponse = async (responseType) => {
     if (!currentAd) return;
     setSubmitting(true);
     const respObj = {
-      adUrl: currentAd,
+      adUrl,
       response: responseType,
       comment: responseType === 'edit' ? comment : '',
       pass: secondPass ? 'second' : 'initial',
+      ...(brandCode ? { brandCode } : {}),
     };
     try {
       await addDoc(collection(db, 'responses'), {
-        clientId: user.uid,
         ...respObj,
         timestamp: serverTimestamp(),
       });
@@ -119,7 +123,7 @@ const Review = ({ user }) => {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen space-y-4">
       <img
-        src={currentAd}
+        src={adUrl}
         alt="Ad"
         className="max-w-full max-h-[80vh] mx-auto rounded shadow"
       />


### PR DESCRIPTION
## Summary
- drop `clientId` when saving review responses
- capture `adUrl` and include `brandCode` when available

## Testing
- `npm test` *(fails: jest not found)*