### PR TITLE
Update sync to use brand codes

### DIFF
--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -24,11 +24,7 @@ const Review = ({ user }) => {
   useEffect(() => {
     const fetchAds = async () => {
       try {
-        const q = query(
-          collection(db, 'adBatches'),
-          where('clientId', '==', user.uid)
-        );
-        const snapshot = await getDocs(q);
+        const snapshot = await getDocs(collection(db, 'adBatches'));
         const list = [];
         snapshot.forEach((doc) => {
           const data = doc.data();
@@ -65,7 +61,6 @@ const Review = ({ user }) => {
     };
     try {
       await addDoc(collection(db, 'responses'), {
-        clientId: user.uid,
         ...respObj,
         timestamp: serverTimestamp(),
       });

--- a/sync.js
+++ b/sync.js
@@ -59,7 +59,7 @@ async function syncBatch(doc) {
   const batchData = doc.data();
   const sheetId = batchData.sheetId;
   if (!sheetId) return;
-  const clientId = batchData.clientId;
+  const brandCode = batchData.brandCode;
 
   const recipes = await fetchRecipes(sheetId);
   for (const r of recipes) {
@@ -70,7 +70,7 @@ async function syncBatch(doc) {
       .collection('ads')
       .doc(r.filename)
       .set({
-        clientId,
+        brandCode,
         filename: r.filename,
         adUrl,
         copy: r.copy,


### PR DESCRIPTION
## Summary
- load `brandCode` from batches in `sync.js` and store on ads
- remove clientId usage in UI

## Testing
- `npm test` *(fails: jest not found)*