### PR TITLE
Query ads subcollections per batch

### DIFF
--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -30,12 +30,20 @@ const Review = ({ user, brandCodes = [] }) => {
         );
         const snapshot = await getDocs(q);
         const list = [];
-        snapshot.forEach((doc) => {
-          const data = doc.data();
-          if (Array.isArray(data.ads)) {
-            list.push(...data.ads);
+        for (const batchDoc of snapshot.docs) {
+          const adsSnap = await getDocs(
+            collection(db, 'adBatches', batchDoc.id, 'ads')
+          );
+          for (const adDoc of adsSnap.docs) {
+            const adData = adDoc.data();
+            list.push({
+              ...adData,
+              ...(batchDoc.data().brandCode
+                ? { brandCode: batchDoc.data().brandCode }
+                : {}),
+            });
           }
-        });
+        }
         setAds(list);
         console.log('Fetched ads:', list);
         console.log('Ad length:', list.length);

--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Review from './Review';
+
+jest.mock('./firebase/config', () => ({ db: {} }));
+
+const getDocs = jest.fn();
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn((...args) => args),
+  query: jest.fn((...args) => args),
+  where: jest.fn(),
+  getDocs: (...args) => getDocs(...args),
+  addDoc: jest.fn(),
+  serverTimestamp: jest.fn(),
+}));
+
+test('loads ads from subcollections', async () => {
+  const batchSnapshot = {
+    docs: [
+      { id: 'batch1', data: () => ({ brandCode: 'BR1' }) },
+    ],
+  };
+  const adsSnapshot = {
+    docs: [
+      { id: 'ad1', data: () => ({ adUrl: 'url1' }) },
+    ],
+  };
+  getDocs.mockResolvedValueOnce(batchSnapshot).mockResolvedValueOnce(adsSnapshot);
+
+  render(<Review user={{ uid: 'u1' }} brandCodes={['BR1']} />);
+
+  await waitFor(() => expect(screen.getByRole('img')).toHaveAttribute('src', 'url1'));
+});


### PR DESCRIPTION
## Summary
- fetch ads from each matched batch's `ads` subcollection
- add unit test verifying ads load from nested collections

## Testing
- `npm test --silent` *(fails: jest not found)*