### PR TITLE
Update Review ads loading and response handling

### DIFF
--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Review from './Review';
 
 jest.mock('./firebase/config', () => ({ db: {} }));
 
 const getDocs = jest.fn();
+const updateDoc = jest.fn();
+const docMock = jest.fn((...args) => args.slice(1).join('/'));
 
 jest.mock('firebase/firestore', () => ({
   collection: jest.fn((...args) => args),
@@ -14,6 +16,8 @@ jest.mock('firebase/firestore', () => ({
   getDocs: (...args) => getDocs(...args),
   addDoc: jest.fn(),
   serverTimestamp: jest.fn(),
+  doc: (...args) => docMock(...args),
+  updateDoc: (...args) => updateDoc(...args),
 }));
 
 afterEach(() => {
@@ -44,5 +48,39 @@ test('loads ads from subcollections', async () => {
 
   await waitFor(() =>
     expect(screen.getByRole('img')).toHaveAttribute('src', 'url1')
+  );
+});
+
+test('submitResponse updates asset status', async () => {
+  const batchSnapshot = { docs: [] };
+  const groupSnapshot = {
+    docs: [{ id: 'group1', data: () => ({ brandCode: 'BR1', name: 'Group 1' }) }],
+  };
+  const assetSnapshot = {
+    docs: [{ id: 'asset1', data: () => ({ firebaseUrl: 'url2' }) }],
+  };
+
+  getDocs
+    .mockResolvedValueOnce(batchSnapshot)
+    .mockResolvedValueOnce(groupSnapshot)
+    .mockResolvedValueOnce(assetSnapshot);
+
+  render(<Review user={{ uid: 'u1' }} brandCodes={['BR1']} />);
+
+  await waitFor(() =>
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'url2')
+  );
+
+  fireEvent.click(screen.getByText('Approve'));
+
+  await waitFor(() => expect(updateDoc).toHaveBeenCalled());
+
+  expect(updateDoc).toHaveBeenCalledWith(
+    'adGroups/group1/assets/asset1',
+    {
+      status: 'approved',
+      comment: '',
+      reviewedBy: 'u1',
+    }
   );
 });


### PR DESCRIPTION
## Summary
- enrich ad objects loaded from adGroups with `assetId`, `adGroupId` and `groupName`
- when submitting a response, update the referenced asset document with status, comment, and reviewer
- extend Review tests to cover asset updating behaviour

## Testing
- `npm test --silent` *(fails: jest not found)*