### PR TITLE
Show group summaries after Review

### DIFF
--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Review from './Review';
 
@@ -45,4 +45,33 @@ test('loads ads from subcollections', async () => {
   await waitFor(() =>
     expect(screen.getByRole('img')).toHaveAttribute('src', 'url1')
   );
+});
+
+test('shows group summary after reviewing ads', async () => {
+  const batchSnapshot = { docs: [] };
+  const groupSnapshot = {
+    docs: [
+      { id: 'g1', data: () => ({ brandCode: 'BR1', name: 'Group 1' }) },
+    ],
+  };
+  const assetSnapshot = {
+    docs: [
+      { id: 'asset1', data: () => ({ firebaseUrl: 'thumb1', adGroupId: 'g1' }) },
+    ],
+  };
+
+  getDocs
+    .mockResolvedValueOnce(batchSnapshot)
+    .mockResolvedValueOnce(groupSnapshot)
+    .mockResolvedValueOnce(assetSnapshot);
+
+  render(<Review user={{ uid: 'u1' }} brandCodes={['BR1']} />);
+
+  await waitFor(() => screen.getByRole('img'));
+
+  fireEvent.click(screen.getByText('Approve'));
+
+  await waitFor(() => screen.getByText('Group 1'));
+  expect(screen.getByText('Group 1')).toBeInTheDocument();
+  expect(screen.getByText(/Approved: 1/)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- track review results per ad group in `Review.jsx`
- add group title, thumbnail, and approved count when all ads reviewed
- test that review screen shows group cards

## Testing
- `npm test --silent` *(fails: jest not found)*