### PR TITLE
Add route for client review

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import { onAuthStateChanged, signOut } from "firebase/auth";
 import { auth } from "./firebase/config";
 import Login from "./Login";
 import Review from "./Review";
+import ClientReview from "./ClientReview";
 import CreateAdGroup from "./CreateAdGroup";
 import AdGroupDetail from "./AdGroupDetail";
 import DesignerDashboard from "./DesignerDashboard";
@@ -124,6 +125,22 @@ const App = () => {
                     loading={roleLoading}
                   >
                     <ClientDashboard user={user} brandCodes={brandCodes} />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/review/:groupId"
+              element={
+                user ? (
+                  <RoleGuard
+                    requiredRole="client"
+                    userRole={role}
+                    loading={roleLoading}
+                  >
+                    <ClientReview user={user} brandCodes={brandCodes} />
                   </RoleGuard>
                 ) : (
                   <Navigate to="/login" replace />

--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { signOut } from 'firebase/auth';
 import { auth, db } from './firebase/config';
 import {
@@ -114,9 +115,10 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
                 })
               : '';
             return (
-              <div
+              <Link
+                to={`/review/${g.id}`}
                 key={g.id}
-                className="border rounded shadow bg-white overflow-hidden"
+                className="border rounded shadow bg-white overflow-hidden block"
               >
                 <div className="flex flex-col md:flex-row">
                   {g.thumbnail && (
@@ -152,7 +154,7 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
                     </div>
                   </div>
                 </div>
-              </div>
+              </Link>
             );
           })}
         </div>

--- a/src/ClientReview.jsx
+++ b/src/ClientReview.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import Review from './Review';
+
+const ClientReview = (props) => {
+  const { groupId } = useParams();
+  return <Review {...props} groupId={groupId} />;
+};
+
+export default ClientReview;

--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -6,6 +6,7 @@ import {
   query,
   where,
   getDocs,
+  getDoc,
   addDoc,
   serverTimestamp,
   doc,
@@ -15,7 +16,7 @@ import {
 } from 'firebase/firestore';
 import { db } from './firebase/config';
 
-const Review = ({ user, brandCodes = [] }) => {
+const Review = ({ user, brandCodes = [], groupId = null }) => {
   const [ads, setAds] = useState([]); // full list of ads
   const [reviewAds, setReviewAds] = useState([]); // ads being reviewed in the current pass
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -33,58 +34,82 @@ const Review = ({ user, brandCodes = [] }) => {
   useEffect(() => {
     const fetchAds = async () => {
       try {
-        const batchQuery = query(
-          collection(db, 'adBatches'),
-          where('brandCode', 'in', brandCodes)
-        );
-        const groupQuery = query(
-          collection(db, 'adGroups'),
-          where('brandCode', 'in', brandCodes),
-          where('status', '==', 'ready')
-        );
+        let list = [];
+        if (groupId) {
+          const groupSnap = await getDoc(doc(db, 'adGroups', groupId));
+          if (groupSnap.exists()) {
+            const assetsSnap = await getDocs(
+              query(
+                collection(db, 'adGroups', groupId, 'assets'),
+                where('status', '==', 'pending')
+              )
+            );
+            list = assetsSnap.docs.map((assetDoc) => ({
+              ...assetDoc.data(),
+              assetId: assetDoc.id,
+              adGroupId: groupId,
+              groupName: groupSnap.data().name,
+              firebaseUrl: assetDoc.data().firebaseUrl,
+              ...(groupSnap.data().brandCode
+                ? { brandCode: groupSnap.data().brandCode }
+                : {}),
+            }));
+          }
+        } else {
+          const batchQuery = query(
+            collection(db, 'adBatches'),
+            where('brandCode', 'in', brandCodes)
+          );
+          const groupQuery = query(
+            collection(db, 'adGroups'),
+            where('brandCode', 'in', brandCodes),
+            where('status', '==', 'ready')
+          );
 
-        const [batchSnap, groupSnap] = await Promise.all([
-          getDocs(batchQuery),
-          getDocs(groupQuery),
-        ]);
+          const [batchSnap, groupSnap] = await Promise.all([
+            getDocs(batchQuery),
+            getDocs(groupQuery),
+          ]);
 
-        const [adsPerBatch, adsPerGroup] = await Promise.all([
-          Promise.all(
-            batchSnap.docs.map(async (batchDoc) => {
-              const adsSnap = await getDocs(
-                collection(db, 'adBatches', batchDoc.id, 'ads')
-              );
-              return adsSnap.docs.map((adDoc) => ({
-                ...adDoc.data(),
-                ...(batchDoc.data().brandCode
-                  ? { brandCode: batchDoc.data().brandCode }
-                  : {}),
-              }));
-            })
-          ),
-          Promise.all(
-            groupSnap.docs.map(async (groupDoc) => {
-              const assetsSnap = await getDocs(
-                query(
-                  collection(db, 'adGroups', groupDoc.id, 'assets'),
-                  where('status', '==', 'pending')
-                )
-              );
-              return assetsSnap.docs.map((assetDoc) => ({
-                ...assetDoc.data(),
-                assetId: assetDoc.id,
-                adGroupId: groupDoc.id,
-                groupName: groupDoc.data().name,
-                firebaseUrl: assetDoc.data().firebaseUrl,
-                ...(groupDoc.data().brandCode
-                  ? { brandCode: groupDoc.data().brandCode }
-                  : {}),
-              }));
-            })
-          ),
-        ]);
+          const [adsPerBatch, adsPerGroup] = await Promise.all([
+            Promise.all(
+              batchSnap.docs.map(async (batchDoc) => {
+                const adsSnap = await getDocs(
+                  collection(db, 'adBatches', batchDoc.id, 'ads')
+                );
+                return adsSnap.docs.map((adDoc) => ({
+                  ...adDoc.data(),
+                  ...(batchDoc.data().brandCode
+                    ? { brandCode: batchDoc.data().brandCode }
+                    : {}),
+                }));
+              })
+            ),
+            Promise.all(
+              groupSnap.docs.map(async (groupDoc) => {
+                const assetsSnap = await getDocs(
+                  query(
+                    collection(db, 'adGroups', groupDoc.id, 'assets'),
+                    where('status', '==', 'pending')
+                  )
+                );
+                return assetsSnap.docs.map((assetDoc) => ({
+                  ...assetDoc.data(),
+                  assetId: assetDoc.id,
+                  adGroupId: groupDoc.id,
+                  groupName: groupDoc.data().name,
+                  firebaseUrl: assetDoc.data().firebaseUrl,
+                  ...(groupDoc.data().brandCode
+                    ? { brandCode: groupDoc.data().brandCode }
+                    : {}),
+                }));
+              })
+            ),
+          ]);
 
-        const list = [...adsPerBatch.flat(), ...adsPerGroup.flat()];
+          list = [...adsPerBatch.flat(), ...adsPerGroup.flat()];
+        }
+
         setAds(list);
         setReviewAds(list);
       } catch (err) {
@@ -94,7 +119,7 @@ const Review = ({ user, brandCodes = [] }) => {
       }
     };
 
-    if (!user?.uid || brandCodes.length === 0) {
+    if (!user?.uid || (!groupId && brandCodes.length === 0)) {
       setAds([]);
       setReviewAds([]);
       setLoading(false);
@@ -102,7 +127,7 @@ const Review = ({ user, brandCodes = [] }) => {
     }
 
     fetchAds();
-  }, [user, brandCodes]);
+  }, [user, brandCodes, groupId]);
 
   const currentAd = reviewAds[currentIndex];
   const adUrl =


### PR DESCRIPTION
## Summary
- add `ClientReview` wrapper component
- allow `Review` to accept a `groupId` prop
- create `/review/:groupId` route
- link client dashboard groups to the new review page

## Testing
- `npm test` *(fails: jest not found)*