### PR TITLE
Update pending version handling

### DIFF
--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -92,7 +92,7 @@ const AdGroupDetail = () => {
       const batch = writeBatch(db);
       for (const asset of assets) {
         batch.update(doc(db, 'adGroups', id, 'assets', asset.id), {
-          status: 'pending',
+          status: 'ready',
           lastUpdatedBy: null,
           lastUpdatedAt: serverTimestamp(),
           history: [],
@@ -182,7 +182,7 @@ const AdGroupDetail = () => {
                 </td>
                 <td className="px-2 py-1">{a.comment || '-'}</td>
                 <td className="px-2 py-1">
-                  {a.status === 'new' ? (
+                  {a.status === 'pending' ? (
                     <div className="flex items-center space-x-2">
                       <input
                         type="file"

--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -45,7 +45,7 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
                 thumbnail = data.firebaseUrl;
               }
               const st = data.status;
-              if (st !== 'pending' && st !== 'new' && st !== 'draft') {
+              if (st !== 'ready' && st !== 'pending' && st !== 'draft') {
                 reviewed += 1;
               }
               if (st === 'approved') approved += 1;

--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -39,7 +39,10 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
           const groupSnap = await getDoc(doc(db, 'adGroups', groupId));
           if (groupSnap.exists()) {
             const assetsSnap = await getDocs(
-              collection(db, 'adGroups', groupId, 'assets')
+              query(
+                collection(db, 'adGroups', groupId, 'assets'),
+                where('status', '==', 'ready')
+              )
             );
             list = assetsSnap.docs.map((assetDoc) => ({
               ...assetDoc.data(),
@@ -87,7 +90,7 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
                 const assetsSnap = await getDocs(
                   query(
                     collection(db, 'adGroups', groupDoc.id, 'assets'),
-                    where('status', '==', 'pending')
+                    where('status', '==', 'ready')
                   )
                 );
                 return assetsSnap.docs.map((assetDoc) => ({
@@ -227,7 +230,7 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
             filename: currentAd.filename || '',
             firebaseUrl: '',
             uploadedAt: null,
-            status: 'new',
+            status: 'pending',
             comment: null,
             lastUpdatedBy: null,
             lastUpdatedAt: serverTimestamp(),

--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -131,7 +131,7 @@ test('request edit creates new version doc', async () => {
   const call = addDoc.mock.calls.find((c) => Array.isArray(c[0]) && c[0][1] === 'adGroups');
   expect(call).toBeTruthy();
   expect(call[1]).toEqual(
-    expect.objectContaining({ parentAdId: 'asset1', version: 2, status: 'new', isResolved: false })
+    expect.objectContaining({ parentAdId: 'asset1', version: 2, status: 'pending', isResolved: false })
   );
 });
 


### PR DESCRIPTION
## Summary
- add filtering for ready assets in `Review` component
- mark assets ready instead of pending when designer publishes
- treat ready assets as unreviewed in the client dashboard
- create new versions with `pending` status
- update tests accordingly

## Testing
- `npm test` *(fails: jest not found)*