### PR TITLE
Update asset workflow statuses

### DIFF
--- a/docs/ad-review-state-management.md
+++ b/docs/ad-review-state-management.md
@@ -35,6 +35,8 @@ Each ad asset (stored under `adGroups/{groupId}/assets/{assetId}`) includes the 
 
 * `history` – append-only array of change objects; newest entry reflects the current status.
 
+Newly uploaded ads start in the `pending` state so they are immediately visible to reviewers.
+
 ## State Transitions
 1. **Loading** – When the review UI loads, it queries all pending ad assets from Firestore and reads the current `status`, `lastUpdatedBy`, `lastUpdatedAt`, and `history` fields.
 2. **Changing Status** – When a reviewer chooses Approve, Reject, or Request Edit:

--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -52,7 +52,7 @@ const AdGroupDetail = () => {
           filename: file.name,
           firebaseUrl: url,
           uploadedAt: serverTimestamp(),
-          status: 'draft',
+          status: 'pending',
           comment: null,
           lastUpdatedBy: null,
           lastUpdatedAt: serverTimestamp(),
@@ -182,7 +182,7 @@ const AdGroupDetail = () => {
                 </td>
                 <td className="px-2 py-1">{a.comment || '-'}</td>
                 <td className="px-2 py-1">
-                  {a.status === 'new' ? (
+                  {!a.firebaseUrl ? (
                     <div className="flex items-center space-x-2">
                       <input
                         type="file"

--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -45,7 +45,7 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
                 thumbnail = data.firebaseUrl;
               }
               const st = data.status;
-              if (st !== 'pending' && st !== 'new' && st !== 'draft') {
+              if (st !== 'pending') {
                 reviewed += 1;
               }
               if (st === 'approved') approved += 1;

--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -227,7 +227,7 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
             filename: currentAd.filename || '',
             firebaseUrl: '',
             uploadedAt: null,
-            status: 'new',
+            status: 'pending',
             comment: null,
             lastUpdatedBy: null,
             lastUpdatedAt: serverTimestamp(),

--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -131,7 +131,7 @@ test('request edit creates new version doc', async () => {
   const call = addDoc.mock.calls.find((c) => Array.isArray(c[0]) && c[0][1] === 'adGroups');
   expect(call).toBeTruthy();
   expect(call[1]).toEqual(
-    expect.objectContaining({ parentAdId: 'asset1', version: 2, status: 'new', isResolved: false })
+    expect.objectContaining({ parentAdId: 'asset1', version: 2, status: 'pending', isResolved: false })
   );
 });
 


### PR DESCRIPTION
## Summary
- set initial asset status to `pending`
- allow upload field when no asset URL instead of checking `new` status
- ensure edits create pending versions
- adjust dashboard reviewed count logic
- update review test expectations
- clarify docs about pending state on upload

## Testing
- `npm test --silent` *(fails: jest not found)*