### PR TITLE
Fix parentAdId when creating revisions

### DIFF
--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -233,7 +233,7 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
             lastUpdatedAt: serverTimestamp(),
             history: [],
             version: (currentAd.version || 1) + 1,
-            parentAdId: currentAd.assetId,
+            parentAdId: currentAd.parentAdId || currentAd.assetId,
             isResolved: false,
           });
         } else if (responseType === 'approve' && currentAd.parentAdId) {

--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -103,7 +103,17 @@ test('request edit creates new version doc', async () => {
     docs: [{ id: 'group1', data: () => ({ brandCode: 'BR1', name: 'Group 1' }) }],
   };
   const assetSnapshot = {
-    docs: [{ id: 'asset1', data: () => ({ firebaseUrl: 'url2', filename: 'f1.png', version: 1 }) }],
+    docs: [
+      {
+        id: 'asset2',
+        data: () => ({
+          firebaseUrl: 'url2',
+          filename: 'f1.png',
+          version: 2,
+          parentAdId: 'asset1',
+        }),
+      },
+    ],
   };
 
   getDocs.mockImplementation((args) => {
@@ -131,7 +141,12 @@ test('request edit creates new version doc', async () => {
   const call = addDoc.mock.calls.find((c) => Array.isArray(c[0]) && c[0][1] === 'adGroups');
   expect(call).toBeTruthy();
   expect(call[1]).toEqual(
-    expect.objectContaining({ parentAdId: 'asset1', version: 2, status: 'pending', isResolved: false })
+    expect.objectContaining({
+      parentAdId: 'asset1',
+      version: 3,
+      status: 'pending',
+      isResolved: false,
+    })
   );
 });
 


### PR DESCRIPTION
## Summary
- link revision parentAdId to root asset
- update tests for new parentAdId behavior

## Testing
- `npm test --silent` *(fails: jest not found)*