### PR TITLE
Resolve assets when approving revisions

### DIFF
--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -237,6 +237,19 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
             isResolved: false,
           });
         } else if (responseType === 'approve' && currentAd.parentAdId) {
+          const relatedQuery = query(
+            collection(db, 'adGroups', currentAd.adGroupId, 'assets'),
+            where('parentAdId', '==', currentAd.parentAdId)
+          );
+          const relatedSnap = await getDocs(relatedQuery);
+          await Promise.all(
+            relatedSnap.docs.map((d) =>
+              updateDoc(
+                doc(db, 'adGroups', currentAd.adGroupId, 'assets', d.id),
+                { isResolved: true }
+              )
+            )
+          );
           await updateDoc(
             doc(
               db,


### PR DESCRIPTION
## Summary
- mark all assets sharing the same parentAdId resolved when approving a revision
- test that approving a revision updates all related documents

## Testing
- `npm test` *(fails: jest not found)*