### PR TITLE
Track client review timestamp

### DIFF
--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -101,7 +101,9 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
           {groups.map((g) => {
-            const isNew = lastLogin && g.lastUpdated && g.lastUpdated > lastLogin;
+            const viewedStr = localStorage.getItem(`lastViewed-${g.id}`);
+            const lastViewed = viewedStr ? new Date(viewedStr) : lastLogin;
+            const isNew = g.lastUpdated && (!lastViewed || g.lastUpdated > lastViewed);
             const date = g.lastUpdated
               ? g.lastUpdated
               : g.createdAt?.toDate

--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -110,7 +110,11 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
 
         setAds(list);
 
-        const lastLogin = user?.metadata?.lastSignInTime
+        const key = groupId ? `lastViewed-${groupId}` : null;
+        const stored = key ? localStorage.getItem(key) : null;
+        const lastLogin = stored
+          ? new Date(stored)
+          : user?.metadata?.lastSignInTime
           ? new Date(user.metadata.lastSignInTime)
           : null;
 
@@ -314,6 +318,12 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
   }
 
   if (currentIndex >= reviewAds.length) {
+    if (groupId) {
+      localStorage.setItem(
+        `lastViewed-${groupId}`,
+        new Date().toISOString()
+      );
+    }
     const allResponses = Object.values(responses);
     const approvedCount = allResponses.filter((r) => r.response === 'approve').length;
     const rejectedAds = ads.filter((a) => {


### PR DESCRIPTION
## Summary
- preserve reviewed status by tracking when a client last viewed a group
- skip showing previously reviewed ads as `NEW` after the user finishes review

## Testing
- `npm test --silent` *(fails: jest not found)*