### PR TITLE
Implement new asset ready workflow

### DIFF
--- a/src/AdGroupDetail.test.jsx
+++ b/src/AdGroupDetail.test.jsx
@@ -57,8 +57,8 @@ test('toggles asset status to ready', async () => {
   );
 
   await screen.findByText('f1.png');
-  const checkbox = screen.getByRole('checkbox');
-  fireEvent.click(checkbox);
+  const select = screen.getByRole('combobox');
+  fireEvent.change(select, { target: { value: 'ready' } });
 
   await waitFor(() => expect(updateDoc).toHaveBeenCalled());
   expect(updateDoc).toHaveBeenCalledWith('adGroups/group1/assets/asset1', { status: 'ready' });
@@ -77,8 +77,8 @@ test('toggles asset status back to pending', async () => {
   );
 
   await screen.findByText('f1.png');
-  const checkbox = screen.getByRole('checkbox');
-  fireEvent.click(checkbox);
+  const select = screen.getByRole('combobox');
+  fireEvent.change(select, { target: { value: 'pending' } });
 
   await waitFor(() => expect(updateDoc).toHaveBeenCalled());
   expect(updateDoc).toHaveBeenCalledWith('adGroups/group1/assets/asset1', { status: 'pending' });

--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -45,7 +45,7 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
                 thumbnail = data.firebaseUrl;
               }
               const st = data.status;
-              if (st !== 'pending') {
+              if (st !== 'ready') {
                 reviewed += 1;
               }
               if (st === 'approved') approved += 1;

--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -87,7 +87,7 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
                 const assetsSnap = await getDocs(
                   query(
                     collection(db, 'adGroups', groupDoc.id, 'assets'),
-                    where('status', '==', 'pending'),
+                    where('status', '==', 'ready'),
                     where('isResolved', '==', false)
                   )
                 );

--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -43,7 +43,7 @@ test('loads ads from subcollections', async () => {
     docs: [
       {
         id: 'asset1',
-        data: () => ({ firebaseUrl: 'url2', status: 'pending', isResolved: false }),
+        data: () => ({ firebaseUrl: 'url2', status: 'ready', isResolved: false }),
       },
     ],
   };
@@ -73,7 +73,7 @@ test('submitResponse updates asset status', async () => {
     docs: [
       {
         id: 'asset1',
-        data: () => ({ firebaseUrl: 'url2', status: 'pending', isResolved: false }),
+        data: () => ({ firebaseUrl: 'url2', status: 'ready', isResolved: false }),
       },
     ],
   };
@@ -120,7 +120,7 @@ test('request edit creates new version doc', async () => {
           firebaseUrl: 'url2',
           filename: 'f1.png',
           version: 1,
-          status: 'pending',
+          status: 'ready',
           isResolved: false,
         }),
       },
@@ -205,11 +205,11 @@ test('shows group summary after reviewing ads', async () => {
     docs: [
       {
         id: 'asset1',
-        data: () => ({ firebaseUrl: 'url1', status: 'pending', isResolved: false }),
+        data: () => ({ firebaseUrl: 'url1', status: 'ready', isResolved: false }),
       },
       {
         id: 'asset2',
-        data: () => ({ firebaseUrl: 'url2', status: 'pending', isResolved: false }),
+        data: () => ({ firebaseUrl: 'url2', status: 'ready', isResolved: false }),
       },
     ],
   };
@@ -254,7 +254,7 @@ test('filters ads by last login and still shows summary', async () => {
         data: () => ({
           firebaseUrl: 'old',
           lastUpdatedAt: { toDate: () => new Date('2024-01-01T00:00:00Z') },
-          status: 'pending',
+          status: 'ready',
           isResolved: false,
         }),
       },
@@ -263,7 +263,7 @@ test('filters ads by last login and still shows summary', async () => {
         data: () => ({
           firebaseUrl: 'new',
           lastUpdatedAt: { toDate: () => new Date('2024-03-01T00:00:00Z') },
-          status: 'pending',
+          status: 'ready',
           isResolved: false,
         }),
       },
@@ -304,11 +304,11 @@ test('resolved ads are excluded from pending review', async () => {
     docs: [
       {
         id: 'asset1',
-        data: () => ({ firebaseUrl: 'url1', status: 'pending', isResolved: false }),
+        data: () => ({ firebaseUrl: 'url1', status: 'ready', isResolved: false }),
       },
       {
         id: 'asset2',
-        data: () => ({ firebaseUrl: 'url2', status: 'pending', isResolved: true }),
+        data: () => ({ firebaseUrl: 'url2', status: 'ready', isResolved: true }),
       },
     ],
   };


### PR DESCRIPTION
## Summary
- auto-upload assets when files selected
- manage asset status with a dropdown
- mark all assets as `ready` with the green button
- show unreviewed assets as `ready` in the client dashboard
- adjust review logic and tests for the new status

## Testing
- `npm test` *(fails: `jest` not found)*