### PR TITLE
Show email and comments in ad asset history

### DIFF
--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -251,7 +251,10 @@ const AdGroupDetail = () => {
                         {h.timestamp?.toDate
                           ? h.timestamp.toDate().toLocaleString()
                           : ''}{' '}
-                        - {h.userId}: {h.action}
+                        - {h.userEmail || h.userId}: {h.action}
+                        {h.action === 'edit_requested' && h.comment
+                          ? ` - ${h.comment}`
+                          : ''}
                       </div>
                     ))}
                   </td>


### PR DESCRIPTION
## Summary
- show user email or fallback to user ID when listing history entries
- include the comment when the action was `edit_requested`

## Testing
- `npx jest --runInBand --testPathPattern=src/AdGroupDetail.test.jsx --color=false` *(fails: jest not installed)*