### PR TITLE
Fix ad container width

### DIFF
--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -438,7 +438,7 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
           </div>
         </div>
       )}
-      <div className="relative flex justify-center items-start w-full">
+      <div className="relative flex justify-center items-start w-fit mx-auto">
         <img
           src={adUrl}
           alt="Ad"


### PR DESCRIPTION
## Summary
- narrow ad container width to fit content so the history panel sits next to the ad

## Testing
- `npm test --silent` *(fails: jest not found)*