### PR TITLE
Use collectionGroup for ad review

### DIFF
--- a/docs/ad-review-state-management.md
+++ b/docs/ad-review-state-management.md
@@ -61,3 +61,10 @@ The system intentionally avoids role-based permissions or locking mechanics. All
 ## Error Handling
 If a status update fails (e.g. network error), the UI should surface the failure to the reviewer and allow them to retry. Firestore writes should be wrapped in try/catch blocks with appropriate user feedback.
 
+## Cross-Collection Queries
+When reviewers open the dashboard they may want to see all ready assets across
+multiple ad groups. The UI uses Firestore's `collectionGroup` queries to read
+every `assets` subcollection in a single request. Because each asset document
+stores its `brandCode`, the query can filter by brand without loading each group
+first.
+

--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -48,6 +48,7 @@ const AdGroupDetail = () => {
         const url = await uploadFile(file, id);
         await addDoc(collection(db, 'adGroups', id, 'assets'), {
           adGroupId: id,
+          brandCode: group?.brandCode || '',
           filename: file.name,
           firebaseUrl: url,
           uploadedAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- add missing collectionGroup import
- switch Review ad fetch to a collectionGroup query
- store brandCode on new ad asset docs
- update Review tests for new query
- document cross-collection queries

## Testing
- `npm test` *(fails: jest not found)*