### PR TITLE
Add role to progress bar and test by role

### DIFF
--- a/src/Review.jsx
+++ b/src/Review.jsx
@@ -422,7 +422,13 @@ const Review = ({ user, brandCodes = [], groupId = null }) => {
       )}
       <div className="relative flex justify-center items-start w-fit mx-auto">
         {!secondPass && (
-          <div className="w-full max-w-md h-2 bg-gray-200 rounded">
+          <div
+            className="w-full max-w-md h-2 bg-gray-200 rounded"
+            role="progressbar"
+            aria-valuenow={progress}
+            aria-valuemin="0"
+            aria-valuemax="100"
+          >
             <div
               className="h-full bg-green-500 transition-all"
               style={{ width: `${progress}%` }}

--- a/src/Review.test.jsx
+++ b/src/Review.test.jsx
@@ -557,11 +557,11 @@ test('progress bar reflects current index', async () => {
   });
   getDoc.mockResolvedValue({ exists: () => true, data: () => ({ name: 'Group 1' }) });
 
-  const { container } = render(<Review user={{ uid: 'u1' }} brandCodes={['BR1']} />);
+  render(<Review user={{ uid: 'u1' }} brandCodes={['BR1']} />);
 
   await waitFor(() => expect(screen.getByRole('img')).toHaveAttribute('src', 'url1'));
 
-  const bar = container.querySelector('.bg-green-500');
+  const bar = screen.getByRole('progressbar').firstChild;
   expect(bar).toHaveStyle('width: 0%');
 
   fireEvent.click(screen.getByText('Approve'));


### PR DESCRIPTION
## Summary
- set `role="progressbar"` and ARIA attributes on the Review progress bar
- update progress bar test to query with `getByRole`

## Testing
- `npm test -- -t 'progress bar'` *(fails: jest not found)*