### PR TITLE
Store asset summary in group docs

### DIFF
--- a/src/CreateAdGroup.jsx
+++ b/src/CreateAdGroup.jsx
@@ -47,6 +47,12 @@ const CreateAdGroup = () => {
         uploadedBy: auth.currentUser?.uid || null,
         createdAt: serverTimestamp(),
         status: 'draft',
+        reviewedCount: 0,
+        approvedCount: 0,
+        editCount: 0,
+        rejectedCount: 0,
+        thumbnailUrl: '',
+        lastUpdated: serverTimestamp(),
       });
       navigate(`/ad-group/${docRef.id}`);
     } catch (err) {

--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -27,27 +27,18 @@ const DesignerDashboard = () => {
           where('uploadedBy', '==', auth.currentUser?.uid || '')
         );
         const snap = await getDocs(q);
-        const list = await Promise.all(
-          snap.docs.map(async (d) => {
-            let approved = 0;
-            let rejected = 0;
-            let edit = 0;
-            const assetsSnap = await getDocs(
-              collection(db, 'adGroups', d.id, 'assets')
-            );
-            assetsSnap.forEach((a) => {
-              const status = a.data().status;
-              if (status === 'approved') approved += 1;
-              if (status === 'rejected') rejected += 1;
-              if (status === 'edit_requested') edit += 1;
-            });
-            return {
-              id: d.id,
-              ...d.data(),
-              counts: { approved, rejected, edit },
-            };
-          })
-        );
+        const list = snap.docs.map((d) => {
+          const data = d.data();
+          return {
+            id: d.id,
+            ...data,
+            counts: {
+              approved: data.approvedCount || 0,
+              rejected: data.rejectedCount || 0,
+              edit: data.editCount || 0,
+            },
+          };
+        });
         setGroups(list);
       } catch (err) {
         console.error('Failed to fetch groups', err);


### PR DESCRIPTION
## Summary
- extend Ad Group schema with cached counts and metadata
- update AdGroupDetail to keep counts and thumbnail in sync
- read cached values in DesignerDashboard
- read cached values and thumbnail in ClientDashboard

## Testing
- `npm test` *(fails: jest not found)*