### PR TITLE
Set Rubik as global font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Campfire</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/global.css
+++ b/src/global.css
@@ -5,6 +5,7 @@
 @layer base {
   body {
     @apply bg-white text-gray-900 font-sans;
+    font-family: 'Rubik', sans-serif;
   }
   h1 {
     @apply text-2xl font-bold mb-2;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{js,jsx}'],
   theme: {
+    fontFamily: {
+      sans: ['Rubik', 'sans-serif'],
+    },
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- load Rubik from Google Fonts
- apply Rubik to body styling
- override Tailwind `font-sans` with Rubik

## Testing
- `npm test` *(fails: jest not found)*