### PR TITLE
Ensure consistent sidebar width on desktop

### DIFF
--- a/src/AccountSettings.jsx
+++ b/src/AccountSettings.jsx
@@ -4,7 +4,7 @@ import Sidebar from './Sidebar';
 const AccountSettings = () => (
   <div className="flex min-h-screen">
     <Sidebar />
-    <div className="flex-grow p-4">
+    <div className="flex-grow p-4 md:ml-56">
       <h1 className="text-2xl mb-4">Account Settings</h1>
       <p>Coming soon...</p>
     </div>

--- a/src/BrandSetup.jsx
+++ b/src/BrandSetup.jsx
@@ -4,7 +4,7 @@ import Sidebar from './Sidebar';
 const BrandSetup = () => (
   <div className="flex min-h-screen">
     <Sidebar />
-    <div className="flex-grow p-4">
+    <div className="flex-grow p-4 md:ml-56">
       <h1 className="text-2xl mb-4">Brand Setup</h1>
       <p>Coming soon...</p>
     </div>

--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -113,7 +113,7 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
   return (
     <div className="flex min-h-screen">
       <Sidebar />
-      <div className="flex-grow p-4">
+      <div className="flex-grow p-4 md:ml-56">
         <h1 className="text-2xl mb-4">Client Dashboard</h1>
       {loading ? (
         <p>Loading groups...</p>

--- a/src/ClientReview.jsx
+++ b/src/ClientReview.jsx
@@ -8,7 +8,7 @@ const ClientReview = (props) => {
   return (
     <div className="flex min-h-screen">
       <Sidebar />
-      <div className="flex-grow">
+      <div className="flex-grow md:ml-56">
         <Review {...props} groupId={groupId} />
       </div>
     </div>

--- a/src/Request.jsx
+++ b/src/Request.jsx
@@ -4,7 +4,7 @@ import Sidebar from './Sidebar';
 const Request = () => (
   <div className="flex min-h-screen">
     <Sidebar />
-    <div className="flex-grow p-4">
+    <div className="flex-grow p-4 md:ml-56">
       <h1 className="text-2xl mb-4">Request</h1>
       <p>Coming soon...</p>
     </div>

--- a/src/Sidebar.jsx
+++ b/src/Sidebar.jsx
@@ -26,7 +26,7 @@ const Sidebar = () => {
   };
 
   return (
-    <div className="w-56 h-screen border-r bg-white p-4 flex flex-col space-y-2">
+    <div className="w-56 md:w-56 h-screen border-r bg-white p-4 flex flex-col space-y-2">
       {tabs.map((tab) => {
         const isActive = tab.path && location.pathname.startsWith(tab.path);
         const classes =

--- a/src/Sidebar.test.jsx
+++ b/src/Sidebar.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import Sidebar from './Sidebar';
+
+jest.mock('./firebase/config', () => ({ auth: {} }));
+jest.mock('firebase/auth', () => ({ signOut: jest.fn() }));
+
+test('sidebar has md width class', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <Sidebar />
+    </MemoryRouter>
+  );
+  const sidebarDiv = container.firstChild;
+  expect(sidebarDiv).toHaveClass('md:w-56');
+  expect(sidebarDiv).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary
- keep sidebar width at `md:w-56`
- offset content with `md:ml-56`
- add snapshot test for sidebar width

## Testing
- `npm test --silent` *(fails: jest not found)*