### PR TITLE
Add designer sidebar

### DIFF
--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -16,6 +16,7 @@ import {
 import { deleteObject, ref } from 'firebase/storage';
 import { db, storage } from './firebase/config';
 import { uploadFile } from './uploadFile';
+import DesignerSidebar from './DesignerSidebar';
 
 const AdGroupDetail = () => {
   const { id } = useParams();
@@ -203,8 +204,10 @@ const AdGroupDetail = () => {
   }
 
   return (
-    <div className="p-4 max-w-3xl mx-auto">
-      <h1 className="text-2xl mb-2">{group.name}</h1>
+    <div className="flex min-h-screen">
+      <DesignerSidebar />
+      <div className="flex-grow p-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl mb-2">{group.name}</h1>
       <p className="text-sm text-gray-500">Brand: {group.brandCode}</p>
       <p className="text-sm text-gray-500 mb-4">Status: {group.status}</p>
 
@@ -330,6 +333,8 @@ const AdGroupDetail = () => {
         >
           {readyLoading ? 'Processing...' : 'Mark as Ready for Review'}
         </button>
+      </div>
+        </div>
       </div>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,8 @@ import ClientDashboard from "./ClientDashboard";
 import Request from "./Request";
 import BrandSetup from "./BrandSetup";
 import AccountSettings from "./AccountSettings";
+import DesignerNotifications from "./DesignerNotifications";
+import DesignerAccountSettings from "./DesignerAccountSettings";
 import RoleGuard from "./RoleGuard";
 import useUserRole from "./useUserRole";
 
@@ -112,6 +114,38 @@ const App = () => {
                     loading={roleLoading}
                   >
                     <DesignerDashboard />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/designer/notifications"
+              element={
+                user ? (
+                  <RoleGuard
+                    requiredRole="designer"
+                    userRole={role}
+                    loading={roleLoading}
+                  >
+                    <DesignerNotifications />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/designer/account-settings"
+              element={
+                user ? (
+                  <RoleGuard
+                    requiredRole="designer"
+                    userRole={role}
+                    loading={roleLoading}
+                  >
+                    <DesignerAccountSettings />
                   </RoleGuard>
                 ) : (
                   <Navigate to="/login" replace />

--- a/src/CreateAdGroup.jsx
+++ b/src/CreateAdGroup.jsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { doc, getDoc, collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { db, auth } from './firebase/config';
+import DesignerSidebar from './DesignerSidebar';
 
 const CreateAdGroup = () => {
   const [name, setName] = useState('');
@@ -63,8 +64,10 @@ const CreateAdGroup = () => {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-10 p-4">
-      <h1 className="text-2xl mb-4">Create Ad Group</h1>
+    <div className="flex min-h-screen">
+      <DesignerSidebar />
+      <div className="flex-grow p-4 max-w-md mx-auto mt-10">
+        <h1 className="text-2xl mb-4">Create Ad Group</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block mb-1 text-sm font-medium">Group Name</label>
@@ -114,6 +117,7 @@ const CreateAdGroup = () => {
           {loading ? 'Creating...' : 'Create Group'}
         </button>
       </form>
+      </div>
     </div>
   );
 };

--- a/src/DesignerAccountSettings.jsx
+++ b/src/DesignerAccountSettings.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import DesignerSidebar from './DesignerSidebar';
+
+const DesignerAccountSettings = () => (
+  <div className="flex min-h-screen">
+    <DesignerSidebar />
+    <div className="flex-grow p-4">
+      <h1 className="text-2xl mb-4">Account Settings</h1>
+      <p>Coming soon...</p>
+    </div>
+  </div>
+);
+
+export default DesignerAccountSettings;

--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { signOut } from 'firebase/auth';
 import { Link } from 'react-router-dom';
 import {
   collection,
@@ -11,6 +10,7 @@ import {
 } from 'firebase/firestore';
 import { listAll, ref, deleteObject } from 'firebase/storage';
 import { auth, db, storage } from './firebase/config';
+import DesignerSidebar from './DesignerSidebar';
 import CreateAdGroup from './CreateAdGroup';
 
 const DesignerDashboard = () => {
@@ -87,16 +87,10 @@ const DesignerDashboard = () => {
   };
 
   return (
-    <div className="p-4">
-      <div className="flex justify-between items-start">
+    <div className="flex min-h-screen">
+      <DesignerSidebar />
+      <div className="flex-grow p-4">
         <h1 className="text-2xl mb-4">Designer Dashboard</h1>
-        <button
-          onClick={() => signOut(auth)}
-          className="btn-logout mt-4"
-        >
-          Log Out
-        </button>
-      </div>
 
       <div className="mb-8">
         <h2 className="text-xl mb-2">My Ad Groups</h2>
@@ -178,6 +172,7 @@ const DesignerDashboard = () => {
         </div>
       )}
     </div>
+  </div>
   );
 };
 

--- a/src/DesignerNotifications.jsx
+++ b/src/DesignerNotifications.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import DesignerSidebar from './DesignerSidebar';
+
+const DesignerNotifications = () => (
+  <div className="flex min-h-screen">
+    <DesignerSidebar />
+    <div className="flex-grow p-4">
+      <h1 className="text-2xl mb-4">Notifications</h1>
+      <p>Coming soon...</p>
+    </div>
+  </div>
+);
+
+export default DesignerNotifications;

--- a/src/DesignerSidebar.jsx
+++ b/src/DesignerSidebar.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { signOut } from 'firebase/auth';
+import { auth } from './firebase/config';
+
+const tabs = [
+  { label: 'Notifications', path: '/designer/notifications' },
+  { label: 'Ad Groups', path: '/dashboard/designer' },
+  { label: 'Upload Ads', path: '/create-group' },
+  { label: 'Account Settings', path: '/designer/account-settings' },
+];
+
+const DesignerSidebar = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = (tab) => {
+    if (tab.path) {
+      navigate(tab.path);
+    }
+  };
+
+  const handleLogout = () => {
+    signOut(auth).catch((err) => console.error('Failed to sign out', err));
+  };
+
+  const menuItems = (
+    <>
+      {tabs.map((tab) => {
+        const isActive = tab.path && location.pathname.startsWith(tab.path);
+        const classes =
+          (isActive
+            ? 'bg-orange-50 text-orange-600 font-medium border border-orange-500 rounded-lg '
+            : 'text-gray-700 hover:bg-gray-100 ') +
+          'w-full text-left px-3 py-2';
+        return (
+          <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
+            {tab.label}
+          </button>
+        );
+      })}
+    </>
+  );
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <div className="hidden md:flex w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
+        {menuItems}
+        <button
+          onClick={handleLogout}
+          className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-left px-3 py-2"
+        >
+          Log Out
+        </button>
+      </div>
+
+      {/* Mobile hamburger */}
+      <button
+        type="button"
+        aria-label="Menu"
+        className="md:hidden fixed top-2 left-2 m-2 text-2xl z-40"
+        onClick={() => setOpen(true)}
+      >
+        &#9776;
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 bg-white p-4 flex flex-col h-full space-y-2 z-50">
+          <button
+            type="button"
+            aria-label="Close menu"
+            className="self-end mb-4 text-2xl"
+            onClick={() => setOpen(false)}
+          >
+            &times;
+          </button>
+          {menuItems}
+          <button
+            onClick={handleLogout}
+            className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-left px-3 py-2"
+          >
+            Log Out
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default DesignerSidebar;

--- a/src/DesignerSidebar.test.jsx
+++ b/src/DesignerSidebar.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import DesignerSidebar from './DesignerSidebar';
+
+jest.mock('./firebase/config', () => ({ auth: {} }));
+jest.mock('firebase/auth', () => ({ signOut: jest.fn() }));
+
+test('designer sidebar has md width class', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <DesignerSidebar />
+    </MemoryRouter>
+  );
+  const sidebarDiv = container.querySelector('.border-r');
+  expect(sidebarDiv).toHaveClass('w-[250px]');
+  expect(sidebarDiv).toHaveClass('md:flex');
+});


### PR DESCRIPTION
## Summary
- create `DesignerSidebar` component
- add placeholder pages for designer notifications and settings
- integrate sidebar into designer dashboard, ad group detail, and create group pages
- expose new designer routes
- test sidebar layout

## Testing
- `npm test` *(fails: jest not found)*