### PR TITLE
Fix extra closing div

### DIFF
--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -336,7 +336,6 @@ const AdGroupDetail = () => {
       </div>
         </div>
       </div>
-    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- fix unterminated expression error by removing an extra closing `div`

## Testing
- `npx esbuild src/AdGroupDetail.jsx --bundle --outfile=/tmp/out.js` *(fails: connect EHOSTUNREACH)*