### PR TITLE
Fix duplicate sidebar in designer ad group view

### DIFF
--- a/src/CreateAdGroup.jsx
+++ b/src/CreateAdGroup.jsx
@@ -6,7 +6,7 @@ import { doc, getDoc, collection, addDoc, serverTimestamp } from 'firebase/fires
 import { db, auth } from './firebase/config';
 import DesignerSidebar from './DesignerSidebar';
 
-const CreateAdGroup = () => {
+const CreateAdGroup = ({ showSidebar = true }) => {
   const [name, setName] = useState('');
   const [brand, setBrand] = useState('');
   const [brandCodes, setBrandCodes] = useState([]);
@@ -65,7 +65,7 @@ const CreateAdGroup = () => {
 
   return (
     <div className="flex min-h-screen">
-      <DesignerSidebar />
+      {showSidebar && <DesignerSidebar />}
       <div className="flex-grow p-4 max-w-md mx-auto mt-10">
         <h1 className="text-2xl mb-4">Create Ad Group</h1>
       <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/CreateAdGroup.test.jsx
+++ b/src/CreateAdGroup.test.jsx
@@ -23,3 +23,12 @@ test('renders Create Ad Group heading', () => {
   );
   expect(screen.getByText(/Create Ad Group/i)).toBeInTheDocument();
 });
+
+test('hides sidebar when showSidebar is false', () => {
+  render(
+    <MemoryRouter>
+      <CreateAdGroup showSidebar={false} />
+    </MemoryRouter>
+  );
+  expect(screen.queryByText(/Log Out/i)).not.toBeInTheDocument();
+});

--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -157,7 +157,7 @@ const DesignerDashboard = () => {
         )}
       </div>
 
-      <CreateAdGroup />
+      <CreateAdGroup showSidebar={false} />
       {viewNote && (
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
           <div className="bg-white p-4 rounded shadow max-w-sm">


### PR DESCRIPTION
## Summary
- allow `CreateAdGroup` to hide its sidebar
- hide sidebar when embedding `CreateAdGroup` inside `DesignerDashboard`
- add regression test for sidebar visibility

## Testing
- `npm test` *(fails: jest not found)*