### PR TITLE
Add admin account creation form

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,10 @@ Create a `vercel.json` file with the following contents:
 
 Without this rule Vercel would serve 404 pages for client-side routes. The
 rewrite ensures navigation works correctly.
+
+## Admin Account Creation
+
+Navigate to `/admin/accounts` to create client or designer accounts. The form
+calls `createUserWithEmailAndPassword` and then writes a user document to
+Firestore. Both operations are wrapped in a `try/catch` block. If either step
+fails the error message is shown so the admin can correct the input and retry.

--- a/src/AdminAccountForm.jsx
+++ b/src/AdminAccountForm.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from './firebase/config';
+import DesignerSidebar from './DesignerSidebar';
+
+const AdminAccountForm = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('client');
+  const [brandCodes, setBrandCodes] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    setLoading(true);
+    try {
+      const cred = await createUserWithEmailAndPassword(auth, email, password);
+      const codes = brandCodes
+        .split(',')
+        .map((c) => c.trim())
+        .filter(Boolean);
+      await setDoc(doc(db, 'users', cred.user.uid), {
+        role,
+        brandCodes: codes,
+      });
+      setSuccess('Account created');
+      setEmail('');
+      setPassword('');
+      setRole('client');
+      setBrandCodes('');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <DesignerSidebar />
+      <div className="flex-grow p-4 max-w-md mx-auto mt-10">
+        <h1 className="text-2xl mb-4">Create Account</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block mb-1 text-sm font-medium">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full p-2 border rounded"
+              required
+            />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm font-medium">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full p-2 border rounded"
+              required
+            />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm font-medium">Role</label>
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              className="w-full p-2 border rounded"
+            >
+              <option value="client">Client</option>
+              <option value="designer">Designer</option>
+            </select>
+          </div>
+          <div>
+            <label className="block mb-1 text-sm font-medium">Brand Codes</label>
+            <input
+              type="text"
+              value={brandCodes}
+              onChange={(e) => setBrandCodes(e.target.value)}
+              className="w-full p-2 border rounded"
+              placeholder="comma,separated,codes"
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          {success && <p className="text-green-600 text-sm">{success}</p>}
+          <button type="submit" className="w-full btn-primary" disabled={loading}>
+            {loading ? 'Creating...' : 'Create Account'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AdminAccountForm;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import BrandSetup from "./BrandSetup";
 import AccountSettings from "./AccountSettings";
 import DesignerNotifications from "./DesignerNotifications";
 import DesignerAccountSettings from "./DesignerAccountSettings";
+import AdminAccountForm from "./AdminAccountForm";
 import RoleGuard from "./RoleGuard";
 import useUserRole from "./useUserRole";
 
@@ -125,6 +126,22 @@ const App = () => {
                     loading={roleLoading}
                   >
                     <DesignerAccountSettings />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/admin/accounts"
+              element={
+                user ? (
+                  <RoleGuard
+                    requiredRole="designer"
+                    userRole={role}
+                    loading={roleLoading}
+                  >
+                    <AdminAccountForm />
                   </RoleGuard>
                 ) : (
                   <Navigate to="/login" replace />


### PR DESCRIPTION
## Summary
- add an admin account creation form for creating client or designer users
- route `/admin/accounts` to the form with `RoleGuard`
- document error handling for account creation failures

## Testing
- `npm test` *(fails: jest not found)*