### PR TITLE
Add admin dashboard view

### DIFF
--- a/src/AdminDashboard.jsx
+++ b/src/AdminDashboard.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import AdminSidebar from './AdminSidebar';
+import DesignerDashboard from './DesignerDashboard';
+
+const AdminDashboard = () => (
+  <div className="flex min-h-screen">
+    <AdminSidebar />
+    <div className="flex-grow">
+      <DesignerDashboard showSidebar={false} />
+    </div>
+  </div>
+);
+
+export default AdminDashboard;

--- a/src/AdminDashboard.test.jsx
+++ b/src/AdminDashboard.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import AdminDashboard from './AdminDashboard';
+
+jest.mock('./firebase/config', () => ({ auth: {}, db: {}, storage: {} }));
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(() => Promise.resolve({ docs: [] })),
+  query: jest.fn(),
+  where: jest.fn(),
+  doc: jest.fn(),
+  deleteDoc: jest.fn(),
+}));
+jest.mock('firebase/storage', () => ({
+  listAll: jest.fn(() => Promise.resolve({ items: [], prefixes: [] })),
+  ref: jest.fn(),
+  deleteObject: jest.fn(),
+}));
+jest.mock('firebase/auth', () => ({ signOut: jest.fn() }));
+
+test('renders admin sidebar and designer dashboard', () => {
+  render(
+    <MemoryRouter>
+      <AdminDashboard />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/Log Out/i)).toBeInTheDocument();
+  expect(screen.getByText(/Designer Dashboard/i)).toBeInTheDocument();
+});

--- a/src/AdminSidebar.jsx
+++ b/src/AdminSidebar.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { signOut } from 'firebase/auth';
+import { auth } from './firebase/config';
+
+const tabs = [
+  { label: 'Ad Groups', path: '/dashboard/admin' },
+  { label: 'Designer View', path: '/dashboard/admin' },
+];
+
+const AdminSidebar = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = (tab) => {
+    if (tab.path) {
+      navigate(tab.path);
+    }
+  };
+
+  const handleLogout = () => {
+    signOut(auth).catch((err) => console.error('Failed to sign out', err));
+  };
+
+  const menuItems = (
+    <>
+      {tabs.map((tab) => {
+        const isActive = tab.path && location.pathname.startsWith(tab.path);
+        const classes =
+          (isActive
+            ? 'bg-orange-50 text-orange-600 font-medium border border-orange-500 rounded-lg '
+            : 'text-gray-700 hover:bg-gray-100 ') +
+          'w-full text-left px-3 py-2';
+        return (
+          <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
+            {tab.label}
+          </button>
+        );
+      })}
+    </>
+  );
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <div className="hidden md:flex w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
+        {menuItems}
+        <button
+          onClick={handleLogout}
+          className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-left px-3 py-2"
+        >
+          Log Out
+        </button>
+      </div>
+
+      {/* Mobile hamburger */}
+      <button
+        type="button"
+        aria-label="Menu"
+        className="md:hidden fixed top-2 left-2 m-2 text-2xl z-40"
+        onClick={() => setOpen(true)}
+      >
+        &#9776;
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 bg-white p-4 flex flex-col h-full space-y-2 z-50">
+          <button
+            type="button"
+            aria-label="Close menu"
+            className="self-end mb-4 text-2xl"
+            onClick={() => setOpen(false)}
+          >
+            &times;
+          </button>
+          {menuItems}
+          <button
+            onClick={handleLogout}
+            className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-left px-3 py-2"
+          >
+            Log Out
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default AdminSidebar;

--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -13,7 +13,7 @@ import { auth, db, storage } from './firebase/config';
 import DesignerSidebar from './DesignerSidebar';
 import CreateAdGroup from './CreateAdGroup';
 
-const DesignerDashboard = () => {
+const DesignerDashboard = ({ showSidebar = true }) => {
   const [groups, setGroups] = useState([]);
   const [loading, setLoading] = useState(true);
   const [viewNote, setViewNote] = useState(null);
@@ -88,7 +88,7 @@ const DesignerDashboard = () => {
 
   return (
     <div className="flex min-h-screen">
-      <DesignerSidebar />
+      {showSidebar && <DesignerSidebar />}
       <div className="flex-grow p-4">
         <h1 className="text-2xl mb-4">Designer Dashboard</h1>
 


### PR DESCRIPTION
## Summary
- add an `AdminDashboard` that mounts the designer dashboard with an admin sidebar
- create `AdminSidebar` component
- support optional sidebar in `DesignerDashboard`
- test that admin dashboard renders expected pieces

## Testing
- `npm test` *(fails: jest not found)*