### PR TITLE
Update designer tab path

### DIFF
--- a/src/AdminSidebar.jsx
+++ b/src/AdminSidebar.jsx
@@ -5,7 +5,7 @@ import { auth } from './firebase/config';
 
 const tabs = [
   { label: 'Ad Groups', path: '/dashboard/admin' },
-  { label: 'Create Brand', path: '/admin/brands' },
+  { label: 'Create Brand', path: '/dashboard/designer' },
   { label: 'Manage Accounts', path: '/admin/accounts' },
 ];
 

--- a/src/AdminSidebar.test.jsx
+++ b/src/AdminSidebar.test.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import AdminSidebar from './AdminSidebar';
 
 jest.mock('./firebase/config', () => ({ auth: {} }));
 jest.mock('firebase/auth', () => ({ signOut: jest.fn() }));
+const navigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => navigate,
+  useLocation: () => ({ pathname: '/current' }),
+}));
 
 test('admin sidebar has md width class', () => {
   const { container } = render(
@@ -16,4 +22,14 @@ test('admin sidebar has md width class', () => {
   const sidebarDiv = container.querySelector('.border-r');
   expect(sidebarDiv).toHaveClass('w-[250px]');
   expect(sidebarDiv).toHaveClass('md:flex');
+});
+
+test('navigates to designer dashboard when Create Brand clicked', () => {
+  render(
+    <MemoryRouter>
+      <AdminSidebar />
+    </MemoryRouter>
+  );
+  fireEvent.click(screen.getByText('Create Brand'));
+  expect(navigate).toHaveBeenCalledWith('/dashboard/designer');
 });


### PR DESCRIPTION
## Summary
- fix AdminSidebar to point designer tab at `/dashboard/designer`
- ensure navigation to designer dashboard is tested

## Testing
- `npm test --silent` *(fails: jest not found)*