### PR TITLE
Add admin tables for managing accounts and brands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,17 @@ Create a `vercel.json` file with the following contents:
 Without this rule Vercel would serve 404 pages for client-side routes. The
 rewrite ensures navigation works correctly.
 
-## Admin Account Creation
+## Admin Account Management
 
-Navigate to `/admin/accounts` to create client or designer accounts. The form
-calls `createUserWithEmailAndPassword` and then writes a user document to
-Firestore. Both operations are wrapped in a `try/catch` block. If either step
-fails the error message is shown so the admin can correct the input and retry.
+Visit `/admin/accounts` to view all user accounts. Admins can edit the role or
+brand codes directly in the table and delete accounts when necessary. To create
+a new account use `/admin/accounts/new`, which opens the original creation
+form. The form calls `createUserWithEmailAndPassword` and then writes a user
+document to Firestore. Both operations are wrapped in a `try/catch` block. If
+either step fails the error message is shown so the admin can correct the input
+and retry.
+
+## Admin Brand Management
+
+Similarly, `/admin/brands` lists all brands with inline edit and delete
+controls. New brands can be added via `/admin/brands/new`.

--- a/src/AdminAccounts.jsx
+++ b/src/AdminAccounts.jsx
@@ -1,0 +1,170 @@
+import React, { useEffect, useState } from 'react';
+import { collection, getDocs, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { db } from './firebase/config';
+import AdminSidebar from './AdminSidebar';
+
+const AdminAccounts = () => {
+  const [accounts, setAccounts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [editId, setEditId] = useState(null);
+  const [form, setForm] = useState({ role: 'client', brandCodes: '' });
+
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      setLoading(true);
+      try {
+        const snap = await getDocs(collection(db, 'users'));
+        const list = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setAccounts(list);
+      } catch (err) {
+        console.error('Failed to fetch accounts', err);
+        setAccounts([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAccounts();
+  }, []);
+
+  const startEdit = (acct) => {
+    setEditId(acct.id);
+    setForm({
+      role: acct.role || 'client',
+      brandCodes: Array.isArray(acct.brandCodes)
+        ? acct.brandCodes.join(',')
+        : '',
+    });
+  };
+
+  const cancelEdit = () => setEditId(null);
+
+  const handleSave = async (id) => {
+    const codes = form.brandCodes
+      .split(',')
+      .map((c) => c.trim())
+      .filter(Boolean);
+    try {
+      await updateDoc(doc(db, 'users', id), {
+        role: form.role,
+        brandCodes: codes,
+      });
+      setAccounts((prev) =>
+        prev.map((a) =>
+          a.id === id ? { ...a, role: form.role, brandCodes: codes } : a
+        )
+      );
+      setEditId(null);
+    } catch (err) {
+      console.error('Failed to update account', err);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this account?')) return;
+    try {
+      await deleteDoc(doc(db, 'users', id));
+      setAccounts((prev) => prev.filter((a) => a.id !== id));
+    } catch (err) {
+      console.error('Failed to delete account', err);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <AdminSidebar />
+      <div className="flex-grow p-4">
+        <h1 className="text-2xl mb-4">Accounts</h1>
+        <a href="/admin/accounts/new" className="underline text-blue-500 block mb-2">Add Account</a>
+        {loading ? (
+          <p>Loading accounts...</p>
+        ) : accounts.length === 0 ? (
+          <p>No accounts found.</p>
+        ) : (
+          <table className="min-w-full border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border px-2 py-1">ID</th>
+                <th className="border px-2 py-1">Role</th>
+                <th className="border px-2 py-1">Brand Codes</th>
+                <th className="border px-2 py-1">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {accounts.map((acct) => (
+                <tr key={acct.id}>
+                  <td className="border px-2 py-1">{acct.id}</td>
+                  <td className="border px-2 py-1">
+                    {editId === acct.id ? (
+                      <select
+                        value={form.role}
+                        onChange={(e) =>
+                          setForm((f) => ({ ...f, role: e.target.value }))
+                        }
+                        className="w-full p-1 border rounded"
+                      >
+                        <option value="client">Client</option>
+                        <option value="designer">Designer</option>
+                        <option value="admin">Admin</option>
+                      </select>
+                    ) : (
+                      acct.role || ''
+                    )}
+                  </td>
+                  <td className="border px-2 py-1">
+                    {editId === acct.id ? (
+                      <input
+                        type="text"
+                        value={form.brandCodes}
+                        onChange={(e) =>
+                          setForm((f) => ({ ...f, brandCodes: e.target.value }))
+                        }
+                        className="w-full p-1 border rounded"
+                      />
+                    ) : Array.isArray(acct.brandCodes) ? (
+                      acct.brandCodes.join(', ')
+                    ) : (
+                      ''
+                    )}
+                  </td>
+                  <td className="border px-2 py-1 text-center">
+                    {editId === acct.id ? (
+                      <>
+                        <button
+                          onClick={() => handleSave(acct.id)}
+                          className="underline text-blue-500 mr-2"
+                        >
+                          Save
+                        </button>
+                        <button onClick={cancelEdit} className="underline">
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => startEdit(acct)}
+                          className="underline text-blue-500 mr-2"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => handleDelete(acct.id)}
+                          className="underline btn-delete"
+                        >
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminAccounts;

--- a/src/AdminBrands.jsx
+++ b/src/AdminBrands.jsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import { collection, getDocs, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { db } from './firebase/config';
+import AdminSidebar from './AdminSidebar';
+
+const AdminBrands = () => {
+  const [brands, setBrands] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [editId, setEditId] = useState(null);
+  const [form, setForm] = useState({ code: '', name: '' });
+
+  useEffect(() => {
+    const fetchBrands = async () => {
+      setLoading(true);
+      try {
+        const snap = await getDocs(collection(db, 'brands'));
+        const list = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setBrands(list);
+      } catch (err) {
+        console.error('Failed to fetch brands', err);
+        setBrands([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBrands();
+  }, []);
+
+  const startEdit = (brand) => {
+    setEditId(brand.id);
+    setForm({ code: brand.code || '', name: brand.name || '' });
+  };
+
+  const cancelEdit = () => setEditId(null);
+
+  const handleSave = async (id) => {
+    try {
+      await updateDoc(doc(db, 'brands', id), {
+        code: form.code,
+        name: form.name,
+      });
+      setBrands((prev) =>
+        prev.map((b) => (b.id === id ? { ...b, code: form.code, name: form.name } : b))
+      );
+      setEditId(null);
+    } catch (err) {
+      console.error('Failed to update brand', err);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this brand?')) return;
+    try {
+      await deleteDoc(doc(db, 'brands', id));
+      setBrands((prev) => prev.filter((b) => b.id !== id));
+    } catch (err) {
+      console.error('Failed to delete brand', err);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <AdminSidebar />
+      <div className="flex-grow p-4">
+        <h1 className="text-2xl mb-4">Brands</h1>
+        <a href="/admin/brands/new" className="underline text-blue-500 block mb-2">Add Brand</a>
+        {loading ? (
+          <p>Loading brands...</p>
+        ) : brands.length === 0 ? (
+          <p>No brands found.</p>
+        ) : (
+          <table className="min-w-full border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border px-2 py-1">Code</th>
+                <th className="border px-2 py-1">Name</th>
+                <th className="border px-2 py-1">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {brands.map((brand) => (
+                <tr key={brand.id}>
+                  <td className="border px-2 py-1">
+                    {editId === brand.id ? (
+                      <input
+                        type="text"
+                        value={form.code}
+                        onChange={(e) => setForm((f) => ({ ...f, code: e.target.value }))}
+                        className="w-full p-1 border rounded"
+                      />
+                    ) : (
+                      brand.code
+                    )}
+                  </td>
+                  <td className="border px-2 py-1">
+                    {editId === brand.id ? (
+                      <input
+                        type="text"
+                        value={form.name}
+                        onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                        className="w-full p-1 border rounded"
+                      />
+                    ) : (
+                      brand.name
+                    )}
+                  </td>
+                  <td className="border px-2 py-1 text-center">
+                    {editId === brand.id ? (
+                      <>
+                        <button onClick={() => handleSave(brand.id)} className="underline text-blue-500 mr-2">
+                          Save
+                        </button>
+                        <button onClick={cancelEdit} className="underline">Cancel</button>
+                      </>
+                    ) : (
+                      <>
+                        <button onClick={() => startEdit(brand)} className="underline text-blue-500 mr-2">
+                          Edit
+                        </button>
+                        <button onClick={() => handleDelete(brand.id)} className="underline btn-delete">
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminBrands;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,9 +23,11 @@ import AccountSettings from "./AccountSettings";
 import DesignerNotifications from "./DesignerNotifications";
 import DesignerAccountSettings from "./DesignerAccountSettings";
 import AdminAccountForm from "./AdminAccountForm";
+import AdminAccounts from "./AdminAccounts";
 import RoleGuard from "./RoleGuard";
 import useUserRole from "./useUserRole";
 import AdminBrandForm from "./AdminBrandForm";
+import AdminBrands from "./AdminBrands";
 
 const App = () => {
   const [user, setUser] = React.useState(null);
@@ -136,6 +138,22 @@ const App = () => {
             />
             <Route
               path="/admin/accounts"
+              element={
+                user ? (
+                  <RoleGuard
+                    requiredRole="admin"
+                    userRole={role}
+                    loading={roleLoading}
+                  >
+                    <AdminAccounts />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/admin/accounts/new"
               element={
                 user ? (
                   <RoleGuard
@@ -280,6 +298,22 @@ const App = () => {
             />
             <Route
               path="/admin/brands"
+              element={
+                user ? (
+                  <RoleGuard
+                    requiredRole="admin"
+                    userRole={role}
+                    loading={roleLoading}
+                  >
+                    <AdminBrands />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/admin/brands/new"
               element={
                 user ? (
                   <RoleGuard


### PR DESCRIPTION
## Summary
- implement `AdminAccounts` component to view/edit/delete accounts
- implement `AdminBrands` component to view/edit/delete brands
- add new routes for admin tables and separate creation forms
- update README with admin management docs

## Testing
- `npm test` *(fails: jest not found)*