### PR TITLE
Enable admin access to ad group details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -285,7 +285,7 @@ const App = () => {
               element={
                 user ? (
                   <RoleGuard
-                    requiredRole="designer"
+                    requiredRole={["designer", "admin"]}
                     userRole={role}
                     loading={roleLoading}
                   >

--- a/src/RoleGuard.jsx
+++ b/src/RoleGuard.jsx
@@ -6,7 +6,15 @@ const RoleGuard = ({ loading, userRole, requiredRole, children }) => {
     return <div className="text-center mt-10">Loading...</div>;
   }
 
-  if (userRole && userRole !== requiredRole) {
+  const allowedRoles = Array.isArray(requiredRole)
+    ? requiredRole
+    : [requiredRole];
+
+  if (
+    requiredRole &&
+    userRole &&
+    !allowedRoles.includes(userRole)
+  ) {
     return <Navigate to={`/dashboard/${userRole}`} replace />;
   }
 


### PR DESCRIPTION
## Summary
- expand `RoleGuard` to support multiple allowed roles
- allow admins to open `/ad-group/:id`

## Testing
- `npm test` *(fails: jest not found)*