### PR TITLE
Add admin claim utility script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ document to Firestore. Both operations are wrapped in a `try/catch` block. If
 either step fails the error message is shown so the admin can correct the input
 and retry.
 
+
+## Setting Admin Custom Claims
+
+After creating an admin user you need to assign the `admin` custom claim so the application recognizes the account as an administrator. Run the provided `setAdminClaim.js` script with the user's UID:
+
+```bash
+node setAdminClaim.js <uid>
+```
+
+The script loads your service account credentials from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable (it also reads variables from `.env` if present). Once executed, the specified user will have `{ admin: true }` in their custom claims. You can verify this in the Firebase console or by fetching the user record with the Admin SDK.
+
 ## Admin Brand Management
 
 Similarly, `/admin/brands` lists all brands with inline edit and delete

--- a/setAdminClaim.js
+++ b/setAdminClaim.js
@@ -1,0 +1,39 @@
+const admin = require('firebase-admin');
+const fs = require('fs');
+const path = require('path');
+
+// Load variables from .env if present (same logic as sync.js)
+const envPath = path.join(__dirname, '.env');
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([^#=]+)\s*=\s*(.*)\s*$/);
+    if (m && !process.env[m[1]]) {
+      process.env[m[1]] = m[2];
+    }
+  }
+}
+
+const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (!serviceAccountPath) {
+  console.error('GOOGLE_APPLICATION_CREDENTIALS env var is not set.');
+  process.exit(1);
+}
+
+admin.initializeApp({
+  credential: admin.credential.cert(require(serviceAccountPath)),
+});
+
+const uid = process.argv[2];
+if (!uid) {
+  console.error('Usage: node setAdminClaim.js <uid>');
+  process.exit(1);
+}
+
+admin.auth().setCustomUserClaims(uid, { admin: true })
+  .then(() => {
+    console.log(`Admin claim set for user ${uid}`);
+  })
+  .catch((err) => {
+    console.error('Error setting admin claim:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add `setAdminClaim.js` helper for assigning `admin` custom user claims
- document how to use the new script and verify claims

## Testing
- `npm test` *(fails: jest not found)*