### PR TITLE
Add email verification workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ const cred = await createUserWithEmailAndPassword(auth, email, password);
 await setDoc(doc(db, 'users', cred.user.uid), { role, brandCodes: codes });
 ```
 
+Newly created accounts will automatically receive a verification email. They
+must verify their address before they can enroll multi-factor authentication.
+
 Users can sign out from the sidebar. `AdminSidebar` exposes a logout button that
 simply calls `signOut`:
 

--- a/src/AdminAccountForm.jsx
+++ b/src/AdminAccountForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { createUserWithEmailAndPassword, sendEmailVerification } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
 import { auth, db } from './firebase/config';
 import AdminSidebar from './AdminSidebar';
@@ -28,7 +28,8 @@ const AdminAccountForm = () => {
         role,
         brandCodes: codes,
       });
-      setSuccess('Account created');
+      await sendEmailVerification(cred.user);
+      setSuccess('Account created. Ask the user to verify their email.');
       setEmail('');
       setPassword('');
       setRole('client');

--- a/src/AdminAccountForm.test.jsx
+++ b/src/AdminAccountForm.test.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AdminAccountForm from './AdminAccountForm';
+
+jest.mock('./AdminSidebar', () => () => <div />);
+
+jest.mock('./firebase/config', () => ({ auth: {}, db: {} }));
+
+const createUserWithEmailAndPassword = jest.fn();
+const sendEmailVerification = jest.fn();
+
+jest.mock('firebase/auth', () => ({
+  createUserWithEmailAndPassword: (...args) => createUserWithEmailAndPassword(...args),
+  sendEmailVerification: (...args) => sendEmailVerification(...args),
+}));
+
+const setDoc = jest.fn();
+const docMock = jest.fn(() => 'userDoc');
+
+jest.mock('firebase/firestore', () => ({
+  doc: (...args) => docMock(...args),
+  setDoc: (...args) => setDoc(...args),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('sends verification email when account is created', async () => {
+  createUserWithEmailAndPassword.mockResolvedValue({ user: { uid: 'u1' } });
+  render(<AdminAccountForm />);
+
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@b.com' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'pass' } });
+  fireEvent.click(screen.getByText('Create Account'));
+
+  await waitFor(() => expect(sendEmailVerification).toHaveBeenCalledWith({ uid: 'u1' }));
+});

--- a/src/EnrollMfa.test.tsx
+++ b/src/EnrollMfa.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EnrollMfa from './EnrollMfa';
+
+jest.mock('./firebase/config', () => ({ auth: {} }));
+
+const sendEmailVerification = jest.fn();
+
+jest.mock('firebase/auth', () => ({
+  RecaptchaVerifier: jest.fn(),
+  PhoneAuthProvider: jest.fn(() => ({ verifyPhoneNumber: jest.fn() })),
+  multiFactor: jest.fn(() => ({ getSession: jest.fn() })),
+  sendEmailVerification: (...args) => sendEmailVerification(...args),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('blocks enrollment when email is unverified', () => {
+  render(<EnrollMfa user={{ emailVerified: false } as any} role="admin" />);
+  expect(screen.getByText(/Please verify your email/i)).toBeInTheDocument();
+  expect(screen.queryByLabelText(/Phone Number/i)).not.toBeInTheDocument();
+});
+
+test('resends verification email when button clicked', () => {
+  render(<EnrollMfa user={{ emailVerified: false } as any} role="admin" />);
+  fireEvent.click(screen.getByText(/Resend Verification Email/i));
+  expect(sendEmailVerification).toHaveBeenCalled();
+});

--- a/src/EnrollMfa.tsx
+++ b/src/EnrollMfa.tsx
@@ -3,6 +3,7 @@ import {
   RecaptchaVerifier,
   PhoneAuthProvider,
   multiFactor,
+  sendEmailVerification,
 } from 'firebase/auth';
 import type { User } from 'firebase/auth';
 import { auth } from './firebase/config';
@@ -25,6 +26,23 @@ const EnrollMfa: React.FC<EnrollMfaProps> = ({ user, role }) => {
 
   if (!user || !['admin', 'client'].includes(role)) {
     return <p className="p-4">MFA enrollment not allowed for this account.</p>;
+  }
+
+  if (!user.emailVerified) {
+    return (
+      <div className="flex justify-center p-4">
+        <div className="w-80 space-y-2">
+          <p>Please verify your email before enrolling MFA</p>
+          <button
+            type="button"
+            className="w-full btn-primary"
+            onClick={() => sendEmailVerification(user)}
+          >
+            Resend Verification Email
+          </button>
+        </div>
+      </div>
+    );
   }
 
   const sendCode = async (e: FormEvent) => {


### PR DESCRIPTION
## Summary
- send a verification email after creating an account
- block MFA enrollment until the user verifies their address
- note email verification requirement in README
- test AdminAccountForm and EnrollMfa behaviours

## Testing
- `npm test` *(fails: jest not found)*