### PR TITLE
Ensure MFA phone numbers use E.164 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ Admin and client accounts must enroll a second factor. After signing in,
 the app checks `multiFactor.enrolledFactors` for the user and redirects to
 `/enroll-mfa` if no factors are present. The enrollment screen sends an SMS
 verification code and completes `multiFactor().enroll()` once confirmed.
+Phone numbers entered on this screen are automatically formatted as E.164,
+so typing `15555551234` will result in `+15555551234` in the field.

--- a/src/EnrollMfa.test.tsx
+++ b/src/EnrollMfa.test.tsx
@@ -38,6 +38,13 @@ test('resends verification email when button clicked', () => {
   expect(sendEmailVerification).toHaveBeenCalled();
 });
 
+test('formats phone number input to E.164', () => {
+  render(<EnrollMfa user={{ emailVerified: true } as any} role="admin" />);
+  const input = screen.getByLabelText(/Phone Number/i) as HTMLInputElement;
+  fireEvent.change(input, { target: { value: '15551234567' } });
+  expect(input.value).toBe('+15551234567');
+});
+
 test('shows message when recent login required', async () => {
   const { multiFactor } = require('firebase/auth');
   multiFactor.mockReturnValue({

--- a/src/EnrollMfa.tsx
+++ b/src/EnrollMfa.tsx
@@ -27,6 +27,16 @@ const EnrollMfa: React.FC<EnrollMfaProps> = ({ user, role }) => {
   const [message, setMessage] = useState<string>('');
   const navigate = useNavigate();
 
+  const formatPhoneNumber = (value: string) => {
+    const digits = value.replace(/\D/g, '');
+    if (!digits) return '';
+    let e164 = digits;
+    if (digits[0] !== '1' && digits.length === 10) {
+      e164 = '1' + digits;
+    }
+    return '+' + e164;
+  };
+
   if (!user || !['admin', 'client'].includes(role)) {
     return <p className="p-4">MFA enrollment not allowed for this account.</p>;
   }
@@ -56,7 +66,10 @@ const EnrollMfa: React.FC<EnrollMfaProps> = ({ user, role }) => {
     try {
       const mfaSession = await multiFactor(auth.currentUser!).getSession();
       const phoneProvider = new PhoneAuthProvider(auth);
-      const phoneOptions = { phoneNumber, session: mfaSession };
+      const phoneOptions = {
+        phoneNumber: formatPhoneNumber(phoneNumber),
+        session: mfaSession,
+      };
       const verifier = new RecaptchaVerifier(
         auth,
         'recaptcha-container',
@@ -104,7 +117,7 @@ const EnrollMfa: React.FC<EnrollMfaProps> = ({ user, role }) => {
               <input
                 type="tel"
                 value={phoneNumber}
-                onChange={(e) => setPhoneNumber(e.target.value)}
+                onChange={(e) => setPhoneNumber(formatPhoneNumber(e.target.value))}
                 className="w-full p-2 border rounded"
                 required
               />


### PR DESCRIPTION
## Summary
- format the phone input so numbers become E.164 compliant
- normalize numbers before calling `verifyPhoneNumber`
- describe automatic phone number formatting in the README
- add a test covering the formatting logic

## Testing
- `npm test` *(fails: jest not found)*