### PR TITLE
Refine storage folder structure

### DIFF
--- a/src/AdGroupDetail.test.jsx
+++ b/src/AdGroupDetail.test.jsx
@@ -9,8 +9,11 @@ jest.mock('./firebase/config', () => ({ db: {} }));
 const getDoc = jest.fn();
 const onSnapshot = jest.fn();
 const updateDoc = jest.fn();
+const getDocs = jest.fn();
 const docMock = jest.fn((...args) => args.slice(1).join('/'));
 const collectionMock = jest.fn((...args) => args);
+const queryMock = jest.fn((...args) => args);
+const whereMock = jest.fn((...args) => args);
 
 jest.mock('firebase/firestore', () => ({
   doc: (...args) => docMock(...args),
@@ -22,6 +25,9 @@ jest.mock('firebase/firestore', () => ({
   writeBatch: jest.fn(() => ({ update: jest.fn(), commit: jest.fn() })),
   addDoc: jest.fn(),
   deleteDoc: jest.fn(),
+  getDocs: (...args) => getDocs(...args),
+  query: (...args) => queryMock(...args),
+  where: (...args) => whereMock(...args),
 }));
 
 jest.mock('firebase/storage', () => ({ ref: jest.fn(), deleteObject: jest.fn() }));
@@ -38,6 +44,7 @@ beforeEach(() => {
     id: 'group1',
     data: () => ({ name: 'Group 1', brandCode: 'BR1', status: 'draft' }),
   });
+  getDocs.mockResolvedValue({ empty: true, docs: [] });
 });
 
 afterEach(() => {

--- a/src/AdminDashboard.jsx
+++ b/src/AdminDashboard.jsx
@@ -48,7 +48,7 @@ const AdminDashboard = () => {
     fetchGroups();
   }, []);
 
-  const deleteGroup = async (groupId) => {
+  const deleteGroup = async (groupId, brandCode, groupName) => {
     if (!window.confirm('Delete this group?')) return;
     try {
       const assetSnap = await getDocs(
@@ -74,7 +74,8 @@ const AdminDashboard = () => {
         await Promise.all(res.items.map((i) => deleteObject(i)));
         await Promise.all(res.prefixes.map((p) => removeFolder(p)));
       };
-      await removeFolder(ref(storage, `adGroups/${groupId}`));
+      const path = `Campfire/Brands/${brandCode}/Adgroups/${groupName}`;
+      await removeFolder(ref(storage, path));
 
       await deleteDoc(doc(db, 'adGroups', groupId));
       setGroups((prev) => prev.filter((g) => g.id !== groupId));
@@ -141,7 +142,7 @@ const AdminDashboard = () => {
                       View Details
                     </Link>
                     <button
-                      onClick={() => deleteGroup(g.id)}
+                      onClick={() => deleteGroup(g.id, g.brandCode, g.name)}
                       className="ml-2 underline btn-delete"
                     >
                       Delete

--- a/src/DesignerDashboard.jsx
+++ b/src/DesignerDashboard.jsx
@@ -51,7 +51,7 @@ const DesignerDashboard = () => {
     fetchGroups();
   }, []);
 
-  const deleteGroup = async (groupId) => {
+  const deleteGroup = async (groupId, brandCode, groupName) => {
     if (!window.confirm('Delete this group?')) return;
     try {
       const assetSnap = await getDocs(
@@ -77,7 +77,8 @@ const DesignerDashboard = () => {
         await Promise.all(res.items.map((i) => deleteObject(i)));
         await Promise.all(res.prefixes.map((p) => removeFolder(p)));
       };
-      await removeFolder(ref(storage, `adGroups/${groupId}`));
+      const path = `Campfire/Brands/${brandCode}/Adgroups/${groupName}`;
+      await removeFolder(ref(storage, path));
 
       await deleteDoc(doc(db, 'adGroups', groupId));
       setGroups((prev) => prev.filter((g) => g.id !== groupId));
@@ -144,7 +145,7 @@ const DesignerDashboard = () => {
                       View Details
                     </Link>
                     <button
-                      onClick={() => deleteGroup(g.id)}
+                      onClick={() => deleteGroup(g.id, g.brandCode, g.name)}
                       className="ml-2 underline btn-delete"
                     >
                       Delete

--- a/src/uploadFile.js
+++ b/src/uploadFile.js
@@ -3,8 +3,19 @@ import { app } from "./firebase/config";
 
 const storage = getStorage(app);
 
-export async function uploadFile(file, adGroupId) {
-  const filePath = `adGroups/${adGroupId}/${file.name}`;
+// Uploads an asset to Firebase Storage using a readable folder structure.
+// Brand and group names are included so the folder path mirrors the UI hierarchy.
+function sanitizeSegment(str) {
+  return (str || '')
+    .replace(/\//g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export async function uploadFile(file, adGroupId, brandName, groupName) {
+  const brandSegment = sanitizeSegment(brandName);
+  const groupSegment = sanitizeSegment(groupName);
+  const filePath = `Campfire/Brands/${brandSegment}/Adgroups/${groupSegment}/${file.name}`;
   const fileRef = ref(storage, filePath);
   await uploadBytes(fileRef, file);
   const downloadURL = await getDownloadURL(fileRef);


### PR DESCRIPTION
## Summary
- store uploaded files under `Campfire/Brands/<brand>/<group>` folders
- support brand name lookup in AdGroup detail
- adjust group delete utilities to remove new storage folders
- update AdGroup detail tests for Firestore mocks

## Testing
- `npm test` *(fails: jest not found)*