### PR TITLE
Add site settings management

### DIFF
--- a/src/AdminSidebar.jsx
+++ b/src/AdminSidebar.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { signOut } from 'firebase/auth';
 import { auth } from './firebase/config';
+import useSiteSettings from './useSiteSettings';
 
-const logoUrl =
+const defaultLogo =
   'https://firebasestorage.googleapis.com/v0/b/tak-campfire-main/o/StudioTak%2Flogo_new.webp?alt=media&token=1f08d552-6c85-444d-ac4f-1e895e97e5bd';
 
 const tabs = [
@@ -11,6 +12,7 @@ const tabs = [
   { label: 'Ad Groups', path: '/dashboard/admin' },
   { label: 'Users', path: '/admin/accounts' },
   { label: 'Brands', path: '/admin/brands' },
+  { label: 'Site Settings', path: '/admin/site-settings' },
   { label: 'MFA Setup', path: '/enroll-mfa' },
 ];
 
@@ -18,6 +20,7 @@ const AdminSidebar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [open, setOpen] = React.useState(false);
+  const { settings } = useSiteSettings();
 
   const handleClick = (tab) => {
     if (tab.path) {
@@ -35,7 +38,7 @@ const AdminSidebar = () => {
         const isActive = tab.path && location.pathname.startsWith(tab.path);
         const classes =
           (isActive
-            ? 'bg-orange-50 text-orange-600 font-medium border border-orange-500 rounded-lg '
+            ? 'text-accent font-medium border border-accent bg-gray-100 '
             : 'text-gray-700 hover:bg-gray-100 ') +
           'w-full text-left px-3 py-2';
         return (
@@ -51,7 +54,11 @@ const AdminSidebar = () => {
     <>
       {/* Desktop sidebar */}
       <div className="hidden md:flex w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
-        <img src={logoUrl} alt="Studio Tak logo" className="mx-auto mb-4 w-32" />
+        <img
+          src={settings.logoUrl || defaultLogo}
+          alt="Studio Tak logo"
+          className="mx-auto mb-4 w-32"
+        />
         {menuItems}
         <button
           onClick={handleLogout}
@@ -81,7 +88,11 @@ const AdminSidebar = () => {
           >
             &times;
           </button>
-          <img src={logoUrl} alt="Studio Tak logo" className="mx-auto mb-4 w-32" />
+          <img
+            src={settings.logoUrl || defaultLogo}
+            alt="Studio Tak logo"
+            className="mx-auto mb-4 w-32"
+          />
           {menuItems}
           <button
             onClick={handleLogout}

--- a/src/AdminSidebar.test.jsx
+++ b/src/AdminSidebar.test.jsx
@@ -33,3 +33,12 @@ test('navigates to brands page when Brands clicked', () => {
   fireEvent.click(screen.getByText('Brands'));
   expect(navigate).toHaveBeenCalledWith('/admin/brands');
 });
+
+test('renders Site Settings tab', () => {
+  render(
+    <MemoryRouter>
+      <AdminSidebar />
+    </MemoryRouter>
+  );
+  expect(screen.getByText('Site Settings')).toBeInTheDocument();
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import AdminBrandForm from "./AdminBrandForm";
 import AdminBrands from "./AdminBrands";
 import EnrollMfa from "./EnrollMfa";
 import RequireMfa from "./RequireMfa";
+import SiteSettings from "./SiteSettings";
 
 const App = () => {
   const [user, setUser] = React.useState(null);
@@ -325,6 +326,22 @@ const App = () => {
                     loading={roleLoading}
                   >
                     <AdminBrands />
+                  </RoleGuard>
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/admin/site-settings"
+              element={
+                user ? (
+                  <RoleGuard
+                    requiredRole="admin"
+                    userRole={role}
+                    loading={roleLoading}
+                  >
+                    <SiteSettings />
                   </RoleGuard>
                 ) : (
                   <Navigate to="/login" replace />

--- a/src/DesignerSidebar.jsx
+++ b/src/DesignerSidebar.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { signOut } from 'firebase/auth';
 import { auth } from './firebase/config';
+import useSiteSettings from './useSiteSettings';
 
-const logoUrl =
+const defaultLogo =
   'https://firebasestorage.googleapis.com/v0/b/tak-campfire-main/o/StudioTak%2Flogo_new.webp?alt=media&token=1f08d552-6c85-444d-ac4f-1e895e97e5bd';
 
 const tabs = [
@@ -17,6 +18,7 @@ const DesignerSidebar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [open, setOpen] = React.useState(false);
+  const { settings } = useSiteSettings();
 
   const handleClick = (tab) => {
     if (tab.path) {
@@ -34,7 +36,7 @@ const DesignerSidebar = () => {
         const isActive = tab.path && location.pathname.startsWith(tab.path);
         const classes =
           (isActive
-            ? 'bg-orange-50 text-orange-600 font-medium border border-orange-500 rounded-lg '
+            ? 'text-accent font-medium border border-accent bg-gray-100 '
             : 'text-gray-700 hover:bg-gray-100 ') +
           'w-full text-left px-3 py-2';
         return (
@@ -50,7 +52,11 @@ const DesignerSidebar = () => {
     <>
       {/* Desktop sidebar */}
       <div className="hidden md:flex w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
-        <img src={logoUrl} alt="Studio Tak logo" className="mx-auto mb-4 w-32" />
+        <img
+          src={settings.logoUrl || defaultLogo}
+          alt="Studio Tak logo"
+          className="mx-auto mb-4 w-32"
+        />
         {menuItems}
         <button
           onClick={handleLogout}
@@ -80,7 +86,11 @@ const DesignerSidebar = () => {
           >
             &times;
           </button>
-          <img src={logoUrl} alt="Studio Tak logo" className="mx-auto mb-4 w-32" />
+          <img
+            src={settings.logoUrl || defaultLogo}
+            alt="Studio Tak logo"
+            className="mx-auto mb-4 w-32"
+          />
           {menuItems}
           <button
             onClick={handleLogout}

--- a/src/Sidebar.jsx
+++ b/src/Sidebar.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { signOut } from 'firebase/auth';
 import { auth } from './firebase/config';
+import useSiteSettings from './useSiteSettings';
 
-const logoUrl =
+const defaultLogo =
   'https://firebasestorage.googleapis.com/v0/b/tak-campfire-main/o/StudioTak%2Flogo_new.webp?alt=media&token=1f08d552-6c85-444d-ac4f-1e895e97e5bd';
 
 const tabs = [
@@ -18,6 +19,7 @@ const Sidebar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [open, setOpen] = React.useState(false);
+  const { settings } = useSiteSettings();
 
   const handleClick = (tab) => {
     if (tab.path) {
@@ -35,7 +37,7 @@ const Sidebar = () => {
         const isActive = tab.path && location.pathname.startsWith(tab.path);
         const classes =
           (isActive
-            ? 'bg-orange-50 text-orange-600 font-medium border border-orange-500 rounded-lg '
+            ? 'text-accent font-medium border border-accent bg-gray-100 '
             : 'text-gray-700 hover:bg-gray-100 ') +
           'w-full text-left px-3 py-2';
         return (
@@ -51,7 +53,11 @@ const Sidebar = () => {
     <>
       {/* Desktop sidebar */}
       <div className="hidden md:flex w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
-        <img src={logoUrl} alt="Studio Tak logo" className="mx-auto mb-4 w-32" />
+        <img
+          src={settings.logoUrl || defaultLogo}
+          alt="Studio Tak logo"
+          className="mx-auto mb-4 w-32"
+        />
         {menuItems}
         <button
           onClick={handleLogout}
@@ -81,7 +87,11 @@ const Sidebar = () => {
           >
             &times;
           </button>
-          <img src={logoUrl} alt="Studio Tak logo" className="mx-auto mb-4 w-32" />
+          <img
+            src={settings.logoUrl || defaultLogo}
+            alt="Studio Tak logo"
+            className="mx-auto mb-4 w-32"
+          />
           {menuItems}
           <button
             onClick={handleLogout}

--- a/src/SiteSettings.jsx
+++ b/src/SiteSettings.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import AdminSidebar from './AdminSidebar';
+import useSiteSettings from './useSiteSettings';
+
+const SiteSettings = () => {
+  const { settings, saveSettings } = useSiteSettings();
+  const [logoUrl, setLogoUrl] = useState('');
+  const [accentColor, setAccentColor] = useState('#ea580c');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setLogoUrl(settings.logoUrl || '');
+    setAccentColor(settings.accentColor || '#ea580c');
+  }, [settings]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage('');
+    try {
+      await saveSettings({ logoUrl, accentColor });
+      setMessage('Settings saved');
+    } catch (err) {
+      console.error('Failed to save settings', err);
+      setMessage('Failed to save settings');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <AdminSidebar />
+      <div className="flex-grow p-4">
+        <h1 className="text-2xl mb-4">Site Settings</h1>
+        <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+          <div>
+            <label className="block mb-1 text-sm font-medium">Logo URL</label>
+            <input
+              type="text"
+              value={logoUrl}
+              onChange={(e) => setLogoUrl(e.target.value)}
+              className="w-full p-2 border rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm font-medium">Accent Color</label>
+            <input
+              type="color"
+              value={accentColor}
+              onChange={(e) => setAccentColor(e.target.value)}
+              className="w-full p-2 border rounded h-10"
+            />
+          </div>
+          {message && <p className="text-sm">{message}</p>}
+          <button type="submit" className="btn-primary" disabled={loading}>
+            {loading ? 'Saving...' : 'Save Settings'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SiteSettings;

--- a/src/global.css
+++ b/src/global.css
@@ -3,6 +3,9 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --accent-color: #ea580c;
+  }
   body {
     @apply bg-white text-gray-900 font-sans;
     font-family: 'Rubik', sans-serif;
@@ -62,6 +65,15 @@
   textarea,
   select {
     @apply border rounded px-2 py-1;
+  }
+  .text-accent {
+    color: var(--accent-color);
+  }
+  .bg-accent {
+    background-color: var(--accent-color);
+  }
+  .border-accent {
+    border-color: var(--accent-color);
   }
 }
 @keyframes approve-bounce {

--- a/src/useSiteSettings.js
+++ b/src/useSiteSettings.js
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from './firebase/config';
+
+const defaultSettings = { logoUrl: '', accentColor: '#ea580c' };
+
+const useSiteSettings = () => {
+  const [settings, setSettings] = useState(defaultSettings);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const snap = await getDoc(doc(db, 'settings', 'site'));
+        if (snap.exists()) {
+          const data = snap.data();
+          setSettings({ ...defaultSettings, ...data });
+          if (data.accentColor) {
+            document.documentElement.style.setProperty(
+              '--accent-color',
+              data.accentColor
+            );
+          }
+        } else {
+          await setDoc(doc(db, 'settings', 'site'), defaultSettings);
+          document.documentElement.style.setProperty(
+            '--accent-color',
+            defaultSettings.accentColor
+          );
+        }
+      } catch (err) {
+        console.error('Failed to fetch site settings', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSettings();
+  }, []);
+
+  useEffect(() => {
+    if (settings.accentColor) {
+      document.documentElement.style.setProperty(
+        '--accent-color',
+        settings.accentColor
+      );
+    }
+  }, [settings.accentColor]);
+
+  const saveSettings = async (newSettings) => {
+    await setDoc(doc(db, 'settings', 'site'), newSettings, { merge: true });
+    setSettings((prev) => ({ ...prev, ...newSettings }));
+  };
+
+  return { settings, loading, saveSettings };
+};
+
+export default useSiteSettings;


### PR DESCRIPTION
## Summary
- introduce `useSiteSettings` hook for logo and accent color
- create `SiteSettings` admin page
- route `/admin/site-settings` behind `RoleGuard`
- show new tab in `AdminSidebar`
- read accent color and logo from settings in all sidebars
- define CSS variable `--accent-color` and helper classes
- update AdminSidebar tests

## Testing
- `npm test` *(fails: jest not found)*