### PR TITLE
Enable Firebase logo upload

### DIFF
--- a/src/SiteSettings.jsx
+++ b/src/SiteSettings.jsx
@@ -1,25 +1,44 @@
 import React, { useEffect, useState } from 'react';
 import AdminSidebar from './AdminSidebar';
 import useSiteSettings from './useSiteSettings';
+import { uploadLogo } from './uploadLogo';
 
 const SiteSettings = () => {
   const { settings, saveSettings } = useSiteSettings();
   const [logoUrl, setLogoUrl] = useState('');
+  const [logoFile, setLogoFile] = useState(null);
   const [accentColor, setAccentColor] = useState('#ea580c');
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
 
   useEffect(() => {
     setLogoUrl(settings.logoUrl || '');
+    setLogoFile(null);
     setAccentColor(settings.accentColor || '#ea580c');
   }, [settings]);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    setLogoFile(file || null);
+    if (file) {
+      setLogoUrl(URL.createObjectURL(file));
+    } else {
+      setLogoUrl(settings.logoUrl || '');
+    }
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
     setMessage('');
     try {
-      await saveSettings({ logoUrl, accentColor });
+      let url = logoUrl;
+      if (logoFile) {
+        url = await uploadLogo(logoFile);
+      }
+      await saveSettings({ logoUrl: url, accentColor });
+      setLogoUrl(url);
+      setLogoFile(null);
       setMessage('Settings saved');
     } catch (err) {
       console.error('Failed to save settings', err);
@@ -36,13 +55,16 @@ const SiteSettings = () => {
         <h1 className="text-2xl mb-4">Site Settings</h1>
         <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
           <div>
-            <label className="block mb-1 text-sm font-medium">Logo URL</label>
+            <label className="block mb-1 text-sm font-medium">Logo</label>
             <input
-              type="text"
-              value={logoUrl}
-              onChange={(e) => setLogoUrl(e.target.value)}
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
               className="w-full p-2 border rounded"
             />
+            {logoUrl && (
+              <img src={logoUrl} alt="Logo preview" className="mt-2 w-32" />
+            )}
           </div>
           <div>
             <label className="block mb-1 text-sm font-medium">Accent Color</label>

--- a/src/uploadLogo.js
+++ b/src/uploadLogo.js
@@ -1,0 +1,12 @@
+import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { app } from './firebase/config';
+
+const storage = getStorage(app);
+
+export async function uploadLogo(file) {
+  const filePath = `Campfire/site-logo/${file.name}`;
+  const fileRef = ref(storage, filePath);
+  await uploadBytes(fileRef, file);
+  const downloadURL = await getDownloadURL(fileRef);
+  return downloadURL;
+}


### PR DESCRIPTION
## Summary
- add a helper to upload the site logo to Firebase Storage
- allow selecting a logo file in `SiteSettings`
- upload the file on save and preview the uploaded logo

## Testing
- `npm test` *(fails: jest not found)*