### PR TITLE
Add accent color 10 theme support

### DIFF
--- a/src/AdminSidebar.jsx
+++ b/src/AdminSidebar.jsx
@@ -38,8 +38,8 @@ const AdminSidebar = () => {
         const isActive = tab.path && location.pathname.startsWith(tab.path);
         const classes =
           (isActive
-            ? 'text-accent font-medium border border-accent '
-            : 'text-gray-700 hover:bg-gray-100 border border-transparent ') +
+            ? 'text-accent font-medium border border-accent bg-accent-10 '
+            : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
           'rounded-lg w-full text-left px-3 py-2';
         return (
           <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>

--- a/src/DesignerSidebar.jsx
+++ b/src/DesignerSidebar.jsx
@@ -36,8 +36,8 @@ const DesignerSidebar = () => {
         const isActive = tab.path && location.pathname.startsWith(tab.path);
         const classes =
           (isActive
-            ? 'text-accent font-medium border border-accent '
-            : 'text-gray-700 hover:bg-gray-100 border border-transparent ') +
+            ? 'text-accent font-medium border border-accent bg-accent-10 '
+            : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
           'rounded-lg w-full text-left px-3 py-2';
         return (
           <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>

--- a/src/Sidebar.jsx
+++ b/src/Sidebar.jsx
@@ -37,8 +37,8 @@ const Sidebar = () => {
         const isActive = tab.path && location.pathname.startsWith(tab.path);
         const classes =
           (isActive
-            ? 'text-accent font-medium border border-accent '
-            : 'text-gray-700 hover:bg-gray-100 border border-transparent ') +
+            ? 'text-accent font-medium border border-accent bg-accent-10 '
+            : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
           'rounded-lg w-full text-left px-3 py-2';
         return (
           <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>

--- a/src/global.css
+++ b/src/global.css
@@ -5,6 +5,7 @@
 @layer base {
   :root {
     --accent-color: #ea580c;
+    --accent-color-10: rgba(234, 88, 12, 0.1);
   }
   body {
     @apply bg-white text-gray-900 font-sans;
@@ -71,6 +72,9 @@
   }
   .bg-accent {
     background-color: var(--accent-color);
+  }
+  .bg-accent-10 {
+    background-color: var(--accent-color-10);
   }
   .border-accent {
     border-color: var(--accent-color);

--- a/src/useSiteSettings.js
+++ b/src/useSiteSettings.js
@@ -4,6 +4,16 @@ import { db } from './firebase/config';
 
 const defaultSettings = { logoUrl: '', accentColor: '#ea580c' };
 
+const hexToRgba = (hex, alpha = 1) => {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  const int = parseInt(h, 16);
+  const r = (int >> 16) & 255;
+  const g = (int >> 8) & 255;
+  const b = int & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
 const useSiteSettings = () => {
   const [settings, setSettings] = useState(defaultSettings);
   const [loading, setLoading] = useState(true);
@@ -15,17 +25,24 @@ const useSiteSettings = () => {
         if (snap.exists()) {
           const data = snap.data();
           setSettings({ ...defaultSettings, ...data });
-          if (data.accentColor) {
-            document.documentElement.style.setProperty(
-              '--accent-color',
-              data.accentColor
-            );
-          }
+          const color = data.accentColor || defaultSettings.accentColor;
+          document.documentElement.style.setProperty(
+            '--accent-color',
+            color
+          );
+          document.documentElement.style.setProperty(
+            '--accent-color-10',
+            hexToRgba(color, 0.1)
+          );
         } else {
           await setDoc(doc(db, 'settings', 'site'), defaultSettings);
           document.documentElement.style.setProperty(
             '--accent-color',
             defaultSettings.accentColor
+          );
+          document.documentElement.style.setProperty(
+            '--accent-color-10',
+            hexToRgba(defaultSettings.accentColor, 0.1)
           );
         }
       } catch (err) {
@@ -43,6 +60,10 @@ const useSiteSettings = () => {
       document.documentElement.style.setProperty(
         '--accent-color',
         settings.accentColor
+      );
+      document.documentElement.style.setProperty(
+        '--accent-color-10',
+        hexToRgba(settings.accentColor, 0.1)
       );
     }
   }, [settings.accentColor]);


### PR DESCRIPTION
## Summary
- add new `--accent-color-10` variable and `bg-accent-10` utility class
- compute `--accent-color-10` from settings using a helper in `useSiteSettings`
- update sidebars to use accent color highlighting on active/hover

## Testing
- `npm test` *(fails: jest not found)*