### PR TITLE
Adjust sidebar logo size and center text

### DIFF
--- a/src/AdminSidebar.jsx
+++ b/src/AdminSidebar.jsx
@@ -40,7 +40,7 @@ const AdminSidebar = () => {
           (isActive
             ? 'text-accent font-medium border border-accent bg-accent-10 '
             : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
-          'rounded-lg w-full text-left px-3 py-2';
+          'rounded-lg w-full text-center px-3 py-2';
         return (
           <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
             {tab.label}
@@ -57,7 +57,7 @@ const AdminSidebar = () => {
         <img
           src={settings.logoUrl || defaultLogo}
           alt="Studio Tak logo"
-          className="mx-auto mb-4 w-32"
+          className="mx-auto mt-4 mb-4 w-40"
         />
         {menuItems}
         <button
@@ -91,7 +91,7 @@ const AdminSidebar = () => {
           <img
             src={settings.logoUrl || defaultLogo}
             alt="Studio Tak logo"
-            className="mx-auto mb-4 w-32"
+            className="mx-auto mt-4 mb-4 w-40"
           />
           {menuItems}
           <button

--- a/src/DesignerSidebar.jsx
+++ b/src/DesignerSidebar.jsx
@@ -38,7 +38,7 @@ const DesignerSidebar = () => {
           (isActive
             ? 'text-accent font-medium border border-accent bg-accent-10 '
             : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
-          'rounded-lg w-full text-left px-3 py-2';
+          'rounded-lg w-full text-center px-3 py-2';
         return (
           <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
             {tab.label}
@@ -55,7 +55,7 @@ const DesignerSidebar = () => {
         <img
           src={settings.logoUrl || defaultLogo}
           alt="Studio Tak logo"
-          className="mx-auto mb-4 w-32"
+          className="mx-auto mt-4 mb-4 w-40"
         />
         {menuItems}
         <button
@@ -89,7 +89,7 @@ const DesignerSidebar = () => {
           <img
             src={settings.logoUrl || defaultLogo}
             alt="Studio Tak logo"
-            className="mx-auto mb-4 w-32"
+            className="mx-auto mt-4 mb-4 w-40"
           />
           {menuItems}
           <button

--- a/src/Sidebar.jsx
+++ b/src/Sidebar.jsx
@@ -39,7 +39,7 @@ const Sidebar = () => {
           (isActive
             ? 'text-accent font-medium border border-accent bg-accent-10 '
             : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
-          'rounded-lg w-full text-left px-3 py-2';
+          'rounded-lg w-full text-center px-3 py-2';
         return (
           <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
             {tab.label}
@@ -56,7 +56,7 @@ const Sidebar = () => {
         <img
           src={settings.logoUrl || defaultLogo}
           alt="Studio Tak logo"
-          className="mx-auto mb-4 w-32"
+          className="mx-auto mt-4 mb-4 w-40"
         />
         {menuItems}
         <button
@@ -90,7 +90,7 @@ const Sidebar = () => {
           <img
             src={settings.logoUrl || defaultLogo}
             alt="Studio Tak logo"
-            className="mx-auto mb-4 w-32"
+            className="mx-auto mt-4 mb-4 w-40"
           />
           {menuItems}
           <button


### PR DESCRIPTION
## Summary
- center text in the sidebar tabs
- enlarge sidebar logos to 10rem and add top margin

## Testing
- `npm test` *(fails: jest not found)*