### PR TITLE
Fix outer container closing div in AdGroupDetail

### DIFF
--- a/src/AdGroupDetail.jsx
+++ b/src/AdGroupDetail.jsx
@@ -367,6 +367,7 @@ const AdGroupDetail = () => {
           {readyLoading ? 'Processing...' : 'Mark as Ready for Review'}
         </button>
       </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- close the outer container in `AdGroupDetail.jsx`

## Testing
- `npm run build` *(fails: vite not found)*