### PR TITLE
Fix extra closing div in ClientDashboard

### DIFF
--- a/src/ClientDashboard.jsx
+++ b/src/ClientDashboard.jsx
@@ -170,7 +170,6 @@ const ClientDashboard = ({ user, brandCodes = [] }) => {
           })}
         </div>
       )}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove stray closing `</div>`

## Testing
- `npm run build` *(fails: vite not found)*