### PR TITLE
Refactor sidebar with common base component

### DIFF
--- a/src/AdminSidebar.jsx
+++ b/src/AdminSidebar.jsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { signOut } from 'firebase/auth';
-import { auth } from './firebase/config';
-import useSiteSettings from './useSiteSettings';
-
-const defaultLogo =
-  'https://firebasestorage.googleapis.com/v0/b/tak-campfire-main/o/StudioTak%2Flogo_new.webp?alt=media&token=1f08d552-6c85-444d-ac4f-1e895e97e5bd';
+import SidebarBase from './components/SidebarBase';
 
 const tabs = [
   { label: 'Dashboard', path: '/dashboard/admin' },
@@ -16,94 +10,7 @@ const tabs = [
   { label: 'MFA Setup', path: '/enroll-mfa' },
 ];
 
-const AdminSidebar = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [open, setOpen] = React.useState(false);
-  const { settings } = useSiteSettings();
-
-  const handleClick = (tab) => {
-    if (tab.path) {
-      navigate(tab.path);
-    }
-  };
-
-  const handleLogout = () => {
-    signOut(auth).catch((err) => console.error('Failed to sign out', err));
-  };
-
-  const menuItems = (
-    <>
-      {tabs.map((tab) => {
-        const isActive = tab.path && location.pathname.startsWith(tab.path);
-        const classes =
-          (isActive
-            ? 'text-accent font-medium border border-accent bg-accent-10 '
-            : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
-          'rounded-lg w-full text-center px-3 py-2';
-        return (
-          <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
-            {tab.label}
-          </button>
-        );
-      })}
-    </>
-  );
-
-  return (
-    <>
-      {/* Desktop sidebar */}
-      <div className="hidden md:flex fixed top-0 left-0 w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
-        <img
-          src={settings.logoUrl || defaultLogo}
-          alt="Studio Tak logo"
-          className="mx-auto mt-4 mb-4 w-40"
-        />
-        {menuItems}
-        <button
-          onClick={handleLogout}
-          className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
-        >
-          Log Out
-        </button>
-      </div>
-
-      {/* Mobile hamburger */}
-      <button
-        type="button"
-        aria-label="Menu"
-        className="md:hidden fixed top-2 left-2 m-2 text-2xl z-40"
-        onClick={() => setOpen(true)}
-      >
-        &#9776;
-      </button>
-
-      {open && (
-        <div className="fixed inset-0 bg-white p-4 flex flex-col h-full space-y-2 z-50">
-          <button
-            type="button"
-            aria-label="Close menu"
-            className="self-end mb-4 text-2xl"
-            onClick={() => setOpen(false)}
-          >
-            &times;
-          </button>
-          <img
-            src={settings.logoUrl || defaultLogo}
-            alt="Studio Tak logo"
-            className="mx-auto mt-4 mb-4 w-40"
-          />
-          {menuItems}
-          <button
-            onClick={handleLogout}
-            className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
-          >
-            Log Out
-          </button>
-        </div>
-      )}
-    </>
-  );
-};
+const AdminSidebar = () => <SidebarBase tabs={tabs} />;
 
 export default AdminSidebar;
+

--- a/src/AdminSidebar.test.jsx
+++ b/src/AdminSidebar.test.jsx
@@ -42,3 +42,4 @@ test('renders Site Settings tab', () => {
   );
   expect(screen.getByText('Site Settings')).toBeInTheDocument();
 });
+

--- a/src/DesignerSidebar.jsx
+++ b/src/DesignerSidebar.jsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { signOut } from 'firebase/auth';
-import { auth } from './firebase/config';
-import useSiteSettings from './useSiteSettings';
-
-const defaultLogo =
-  'https://firebasestorage.googleapis.com/v0/b/tak-campfire-main/o/StudioTak%2Flogo_new.webp?alt=media&token=1f08d552-6c85-444d-ac4f-1e895e97e5bd';
+import SidebarBase from './components/SidebarBase';
 
 const tabs = [
   { label: 'Notifications', path: '/designer/notifications' },
@@ -14,94 +8,7 @@ const tabs = [
   { label: 'Account Settings', path: '/designer/account-settings' },
 ];
 
-const DesignerSidebar = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [open, setOpen] = React.useState(false);
-  const { settings } = useSiteSettings();
-
-  const handleClick = (tab) => {
-    if (tab.path) {
-      navigate(tab.path);
-    }
-  };
-
-  const handleLogout = () => {
-    signOut(auth).catch((err) => console.error('Failed to sign out', err));
-  };
-
-  const menuItems = (
-    <>
-      {tabs.map((tab) => {
-        const isActive = tab.path && location.pathname.startsWith(tab.path);
-        const classes =
-          (isActive
-            ? 'text-accent font-medium border border-accent bg-accent-10 '
-            : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
-          'rounded-lg w-full text-center px-3 py-2';
-        return (
-          <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
-            {tab.label}
-          </button>
-        );
-      })}
-    </>
-  );
-
-  return (
-    <>
-      {/* Desktop sidebar */}
-      <div className="hidden md:flex fixed top-0 left-0 w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
-        <img
-          src={settings.logoUrl || defaultLogo}
-          alt="Studio Tak logo"
-          className="mx-auto mt-4 mb-4 w-40"
-        />
-        {menuItems}
-        <button
-          onClick={handleLogout}
-          className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
-        >
-          Log Out
-        </button>
-      </div>
-
-      {/* Mobile hamburger */}
-      <button
-        type="button"
-        aria-label="Menu"
-        className="md:hidden fixed top-2 left-2 m-2 text-2xl z-40"
-        onClick={() => setOpen(true)}
-      >
-        &#9776;
-      </button>
-
-      {open && (
-        <div className="fixed inset-0 bg-white p-4 flex flex-col h-full space-y-2 z-50">
-          <button
-            type="button"
-            aria-label="Close menu"
-            className="self-end mb-4 text-2xl"
-            onClick={() => setOpen(false)}
-          >
-            &times;
-          </button>
-          <img
-            src={settings.logoUrl || defaultLogo}
-            alt="Studio Tak logo"
-            className="mx-auto mt-4 mb-4 w-40"
-          />
-          {menuItems}
-          <button
-            onClick={handleLogout}
-            className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
-          >
-            Log Out
-          </button>
-        </div>
-      )}
-    </>
-  );
-};
+const DesignerSidebar = () => <SidebarBase tabs={tabs} />;
 
 export default DesignerSidebar;
+

--- a/src/DesignerSidebar.test.jsx
+++ b/src/DesignerSidebar.test.jsx
@@ -17,3 +17,4 @@ test('designer sidebar has md width class', () => {
   expect(sidebarDiv).toHaveClass('w-[250px]');
   expect(sidebarDiv).toHaveClass('md:flex');
 });
+

--- a/src/RoleSidebar.jsx
+++ b/src/RoleSidebar.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+// These components are thin wrappers around SidebarBase that supply
+// role specific tab configurations.
 import Sidebar from './Sidebar';
 import AdminSidebar from './AdminSidebar';
 import DesignerSidebar from './DesignerSidebar';

--- a/src/Sidebar.jsx
+++ b/src/Sidebar.jsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { signOut } from 'firebase/auth';
-import { auth } from './firebase/config';
-import useSiteSettings from './useSiteSettings';
-
-const defaultLogo =
-  'https://firebasestorage.googleapis.com/v0/b/tak-campfire-main/o/StudioTak%2Flogo_new.webp?alt=media&token=1f08d552-6c85-444d-ac4f-1e895e97e5bd';
+import SidebarBase from './components/SidebarBase';
 
 const tabs = [
   { label: 'Dashboard', path: '/dashboard/client' },
@@ -15,94 +9,7 @@ const tabs = [
   { label: 'MFA Setup', path: '/enroll-mfa' },
 ];
 
-const Sidebar = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [open, setOpen] = React.useState(false);
-  const { settings } = useSiteSettings();
-
-  const handleClick = (tab) => {
-    if (tab.path) {
-      navigate(tab.path);
-    }
-  };
-
-  const handleLogout = () => {
-    signOut(auth).catch((err) => console.error('Failed to sign out', err));
-  };
-
-  const menuItems = (
-    <>
-      {tabs.map((tab) => {
-        const isActive = tab.path && location.pathname.startsWith(tab.path);
-        const classes =
-          (isActive
-            ? 'text-accent font-medium border border-accent bg-accent-10 '
-            : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
-          'rounded-lg w-full text-center px-3 py-2';
-        return (
-          <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
-            {tab.label}
-          </button>
-        );
-      })}
-    </>
-  );
-
-  return (
-    <>
-      {/* Desktop sidebar */}
-      <div className="hidden md:flex fixed top-0 left-0 w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
-        <img
-          src={settings.logoUrl || defaultLogo}
-          alt="Studio Tak logo"
-          className="mx-auto mt-4 mb-4 w-40"
-        />
-        {menuItems}
-        <button
-          onClick={handleLogout}
-          className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
-        >
-          Log Out
-        </button>
-      </div>
-
-      {/* Mobile hamburger */}
-      <button
-        type="button"
-        aria-label="Menu"
-        className="md:hidden fixed top-2 left-2 m-2 text-2xl z-40"
-        onClick={() => setOpen(true)}
-      >
-        &#9776;
-      </button>
-
-      {open && (
-        <div className="fixed inset-0 bg-white p-4 flex flex-col h-full space-y-2 z-50">
-          <button
-            type="button"
-            aria-label="Close menu"
-            className="self-end mb-4 text-2xl"
-            onClick={() => setOpen(false)}
-          >
-            &times;
-          </button>
-          <img
-            src={settings.logoUrl || defaultLogo}
-            alt="Studio Tak logo"
-            className="mx-auto mt-4 mb-4 w-40"
-          />
-          {menuItems}
-          <button
-            onClick={handleLogout}
-            className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
-          >
-            Log Out
-          </button>
-        </div>
-      )}
-    </>
-  );
-};
+const Sidebar = () => <SidebarBase tabs={tabs} />;
 
 export default Sidebar;
+

--- a/src/Sidebar.test.jsx
+++ b/src/Sidebar.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
-import Sidebar from './Sidebar';
+import SidebarBase from './components/SidebarBase';
 
 jest.mock('./firebase/config', () => ({ auth: {} }));
 jest.mock('firebase/auth', () => ({ signOut: jest.fn() }));
@@ -10,10 +10,11 @@ jest.mock('firebase/auth', () => ({ signOut: jest.fn() }));
 test('sidebar has md width class', () => {
   const { container } = render(
     <MemoryRouter>
-      <Sidebar />
+      <SidebarBase tabs={[{ label: 'Home', path: '/' }]} />
     </MemoryRouter>
   );
   const sidebarDiv = container.querySelector('.border-r');
   expect(sidebarDiv).toHaveClass('w-[250px]');
   expect(sidebarDiv).toHaveClass('md:flex');
 });
+

--- a/src/components/SidebarBase.jsx
+++ b/src/components/SidebarBase.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { signOut } from 'firebase/auth';
+import { auth } from '../firebase/config';
+import useSiteSettings from '../useSiteSettings';
+
+const defaultLogo =
+  'https://firebasestorage.googleapis.com/v0/b/tak-campfire-main/o/StudioTak%2Flogo_new.webp?alt=media&token=1f08d552-6c85-444d-ac4f-1e895e97e5bd';
+
+const SidebarBase = ({ tabs }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [open, setOpen] = React.useState(false);
+  const { settings } = useSiteSettings();
+
+  const handleClick = (tab) => {
+    if (tab.path) {
+      navigate(tab.path);
+    }
+  };
+
+  const handleLogout = () => {
+    signOut(auth).catch((err) => console.error('Failed to sign out', err));
+  };
+
+  const menuItems = (
+    <>
+      {tabs.map((tab) => {
+        const isActive = tab.path && location.pathname.startsWith(tab.path);
+        const classes =
+          (isActive
+            ? 'text-accent font-medium border border-accent bg-accent-10 '
+            : 'text-gray-700 hover:bg-accent-10 border border-transparent ') +
+          'rounded-lg w-full text-center px-3 py-2';
+        return (
+          <button key={tab.label} onClick={() => handleClick(tab)} className={classes}>
+            {tab.label}
+          </button>
+        );
+      })}
+    </>
+  );
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <div className="hidden md:flex fixed top-0 left-0 w-[250px] h-screen border-r bg-white p-4 flex-col space-y-2">
+        <img
+          src={settings.logoUrl || defaultLogo}
+          alt="Studio Tak logo"
+          className="mx-auto mt-4 mb-4 w-40"
+        />
+        {menuItems}
+        <button
+          onClick={handleLogout}
+          className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
+        >
+          Log Out
+        </button>
+      </div>
+
+      {/* Mobile hamburger */}
+      <button
+        type="button"
+        aria-label="Menu"
+        className="md:hidden fixed top-2 left-2 m-2 text-2xl z-40"
+        onClick={() => setOpen(true)}
+      >
+        &#9776;
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 bg-white p-4 flex flex-col h-full space-y-2 z-50">
+          <button
+            type="button"
+            aria-label="Close menu"
+            className="self-end mb-4 text-2xl"
+            onClick={() => setOpen(false)}
+          >
+            &times;
+          </button>
+          <img
+            src={settings.logoUrl || defaultLogo}
+            alt="Studio Tak logo"
+            className="mx-auto mt-4 mb-4 w-40"
+          />
+          {menuItems}
+          <button
+            onClick={handleLogout}
+            className="mt-auto text-gray-700 hover:bg-gray-100 w-full text-center font-bold px-3 py-2"
+          >
+            Log Out
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SidebarBase;


### PR DESCRIPTION
## Summary
- create `SidebarBase` with shared layout logic
- convert `Sidebar`, `AdminSidebar` and `DesignerSidebar` to wrappers
- adjust `RoleSidebar` comments
- point sidebar test at `SidebarBase`

## Testing
- `npm test` *(fails: jest not found)*